### PR TITLE
Update filesystem_storage.py

### DIFF
--- a/tsdat/io/filesystem_storage.py
+++ b/tsdat/io/filesystem_storage.py
@@ -5,6 +5,7 @@ import pathlib
 import zipfile
 
 import datetime
+import _strptime # added to workaround https://bugs.python.org/issue8098, causes issues on some machines
 import os
 import shutil
 import xarray as xr


### PR DESCRIPTION
added import _strptime to avoid threadlocking issues on some machines (https://bugs.python.org/issue8098)