### PR TITLE
Only run "Upload to PyPi" steps if running as tsdat

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -37,6 +37,7 @@ jobs:
     - run: python -m build --sdist --wheel --outdir dist/ .
 
     - name: Upload to Test PyPI
+      if: github.repository_owner == 'tsdat'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
@@ -44,7 +45,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Upload to PyPI (tagged release only)
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: github.repository_owner == 'tsdat' && github.event_name == 'release' && github.event.action == 'published'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__


### PR DESCRIPTION
Added a conditional statement that checks to see if the repository owner is "tsdat". If not, then the "Upload to TestPyPi" and "Upload to PyPi" steps will be skipped. 

Without this check the build and publish GitHub Action will always fail on forked repositories because the user will likely not have permissions to publish to the tsdat repo on pypi or test pypi servers (or, worse, they *will* have permission and then a package will be released from a source other than https://github.com/tsdat/tsdat).

It is useful to check that the package still *builds* correctly, so we only skip the release step instead of disabling the whole workflow on forked repos.