### PR TITLE
Fix global marine ingest tutorial

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: docs
+docs:
+	@ make clean
+	@ make html


### PR DESCRIPTION
The tutorial was broken ( #26 ). This PR addresses the following issues with it:

- [X] Indicate that python 3.8+ should be used.
- [X] Added requirements: do `pip install -r requirements.txt` instead of `pip install tsdat`.
- [X] Fixed a broken link to the data standards.
- [X] Fixed over-indented yaml snippets, including one case where the indentation made the yaml invalid (converter section for `time` in the pipeline config file).
- [X] Updated the config files to use different variables since the `Ice Accretion Source` variable is no longer available in the reference data.