### PR TITLE
Rename `FileHandler` objects

### DIFF
--- a/examples/a2e_buoy_ingest/config/storage_config.yml
+++ b/examples/a2e_buoy_ingest/config/storage_config.yml
@@ -1,6 +1,5 @@
-
 storage:
-  classname:  tsdat.io.FilesystemStorage
+  classname: tsdat.io.FilesystemStorage
   parameters:
     retain_input_files: True
     root_dir: ${CONFIG_DIR}/../storage/root
@@ -9,9 +8,9 @@ storage:
     input:
       csv:
         file_pattern: '.*\.csv'
-        classname: tsdat.io.filehandlers.CsvHandler
+        classname: tsdat.io.handlers.CsvHandler
 
     output:
       netcdf:
-        file_extension: '.nc'
-        classname: tsdat.io.filehandlers.NetCdfHandler
+        file_extension: ".nc"
+        classname: tsdat.io.handlers.NetCdfHandler

--- a/examples/a2e_imu_ingest/__init__.py
+++ b/examples/a2e_imu_ingest/__init__.py
@@ -1,5 +1,5 @@
 import os
-from .pipeline import ImuIngestPipeline, ImuFileHandler
+from .pipeline import ImuIngestPipeline, ImuReader
 from . import pipeline
 
 

--- a/examples/a2e_imu_ingest/config/storage_config.yml
+++ b/examples/a2e_imu_ingest/config/storage_config.yml
@@ -1,6 +1,5 @@
-
 storage:
-  classname:  tsdat.io.FilesystemStorage
+  classname: tsdat.io.FilesystemStorage
   parameters:
     retain_input_files: True
     root_dir: ${CONFIG_DIR}/../storage/root
@@ -9,9 +8,9 @@ storage:
     input:
       imu:
         file_pattern: '.*\.bin'
-        classname: examples.a2e_imu_ingest.pipeline.filehandlers.ImuFileHandler
+        classname: examples.a2e_imu_ingest.pipeline.handlers.ImuReader
 
     output:
       netcdf:
-        file_extension: '.nc'
-        classname: tsdat.io.filehandlers.NetCdfHandler
+        file_extension: ".nc"
+        classname: tsdat.io.handlers.NetCdfHandler

--- a/examples/a2e_imu_ingest/pipeline/__init__.py
+++ b/examples/a2e_imu_ingest/pipeline/__init__.py
@@ -1,2 +1,2 @@
-from .filehandlers import ImuFileHandler
+from .handlers import ImuReader
 from .pipeline import ImuIngestPipeline

--- a/examples/a2e_imu_ingest/pipeline/handlers.py
+++ b/examples/a2e_imu_ingest/pipeline/handlers.py
@@ -4,8 +4,7 @@ import numpy as np
 import xarray as xr
 from typing import Dict
 
-from tsdat import Config
-from tsdat.io import AbstractFileHandler
+from tsdat.io import DataHandler
 
 
 class DTYPE:
@@ -148,7 +147,7 @@ def extract_data(filename: str, packet: Dict[str, Dict]) -> xr.Dataset:
                         _data = fread(bfile, dtype)
                         if name:
                             raw_data[category][name].append(_data)
-        except:
+        except BaseException:
             pass
 
     # Convert raw data into numpy arrays
@@ -199,19 +198,14 @@ def extract_data(filename: str, packet: Dict[str, Dict]) -> xr.Dataset:
     return xr.Dataset.from_dict(dictionary)
 
 
-class ImuFileHandler(AbstractFileHandler):
-    def write(self, ds: xr.Dataset, filename: str, config: Config, **kwargs):
-        raise NotImplementedError(
-            "Error: this file format should not be used to write to."
-        )
-
+class ImuReader(DataHandler):
     def read(self, filename: str, **kwargs) -> xr.Dataset:
 
         # Determine which packet to use.
         dataset = None
         try:
             dataset = extract_data(filename, morro_packet)
-        except:
+        except BaseException:
             dataset = extract_data(filename, humbolt_packet)
 
         return dataset

--- a/examples/a2e_lidar_ingest/__init__.py
+++ b/examples/a2e_lidar_ingest/__init__.py
@@ -1,5 +1,5 @@
 import os
-from .pipeline import LidarIngestPipeline, StaFileHandler
+from .pipeline import LidarIngestPipeline, StaReader
 from . import pipeline
 
 

--- a/examples/a2e_lidar_ingest/config/storage_config.yml
+++ b/examples/a2e_lidar_ingest/config/storage_config.yml
@@ -1,6 +1,5 @@
-
 storage:
-  classname:  tsdat.io.FilesystemStorage
+  classname: tsdat.io.FilesystemStorage
   parameters:
     retain_input_files: True
     root_dir: ${CONFIG_DIR}/../storage/root
@@ -9,8 +8,8 @@ storage:
     input:
       sta:
         file_pattern: '.*\.sta\.7z'
-        classname: examples.a2e_lidar_ingest.pipeline.filehandlers.StaFileHandler
+        classname: examples.a2e_lidar_ingest.pipeline.handlers.StaReader
     output:
       netcdf:
-        file_extension: '.nc'
-        classname: tsdat.io.filehandlers.NetCdfHandler
+        file_extension: ".nc"
+        classname: tsdat.io.handlers.NetCdfHandler

--- a/examples/a2e_lidar_ingest/pipeline/__init__.py
+++ b/examples/a2e_lidar_ingest/pipeline/__init__.py
@@ -1,3 +1,3 @@
-from .filehandlers import StaFileHandler
+from .handlers import StaReader
 from .pipeline import LidarIngestPipeline
-from . import filehandlers, pipeline
+from . import handlers, pipeline

--- a/examples/a2e_lidar_ingest/pipeline/handlers.py
+++ b/examples/a2e_lidar_ingest/pipeline/handlers.py
@@ -1,33 +1,17 @@
 import lzma
 import xarray as xr
 import pandas as pd
-from tsdat.io import AbstractFileHandler
+from tsdat.io import DataHandler
 from tsdat import Config
 
 
-class StaFileHandler(AbstractFileHandler):
+class StaReader(DataHandler):
     """-------------------------------------------------------------------
     Custom file handler for reading custom *.sta.7z files. These files are
-    encoded using cp1252 and the lzma algorithm
+    encoded using cp1252 and the lzma algorithm.
 
-    See https://tsdat.readthedocs.io/ for more file handler examples.
+    See https://tsdat.readthedocs.io/ for more `FileHandler` examples.
     -------------------------------------------------------------------"""
-
-    def write(self, ds: xr.Dataset, filename: str, config: Config, **kwargs):
-        """-------------------------------------------------------------------
-        Classes derived from the FileHandler class can implement this method
-        to save to a custom file format.
-
-        Args:
-            ds (xr.Dataset): The dataset to save.
-            filename (str): An absolute or relative path to the file including
-                            filename.
-            config (Config, optional):  Optional Config object. Defaults to
-                                        None.
-        -------------------------------------------------------------------"""
-        raise NotImplementedError(
-            "Error: this file format should not be used to write to."
-        )
 
     def read(self, filename: str, **kwargs) -> xr.Dataset:
         """-------------------------------------------------------------------

--- a/examples/a2e_waves_ingest/config/storage_config.yml
+++ b/examples/a2e_waves_ingest/config/storage_config.yml
@@ -1,6 +1,5 @@
-
 storage:
-  classname:  tsdat.io.FilesystemStorage
+  classname: tsdat.io.FilesystemStorage
   parameters:
     retain_input_files: True
     root_dir: ${CONFIG_DIR}/../storage/root
@@ -9,9 +8,9 @@ storage:
     input:
       imu:
         file_pattern: '.*waves\.csv'
-        classname: tsdat.io.filehandlers.CsvHandler
+        classname: tsdat.io.handlers.CsvHandler
 
     output:
       netcdf:
-        file_extension: '.nc'
-        classname: tsdat.io.filehandlers.NetCdfHandler
+        file_extension: ".nc"
+        classname: tsdat.io.handlers.NetCdfHandler

--- a/tests/config/storage.yml
+++ b/tests/config/storage.yml
@@ -1,6 +1,5 @@
-
 storage:
-  classname:  tsdat.io.FilesystemStorage
+  classname: tsdat.io.FilesystemStorage
   parameters:
     retain_input_files: True
     root_dir: ${CONFIG_DIR}/../storage/root
@@ -9,12 +8,12 @@ storage:
     input:
       csv:
         file_pattern: ['.*\.csv']
-        classname: tsdat.io.filehandlers.CsvHandler
+        classname: tsdat.io.handlers.CsvHandler
 
     output:
       netcdf:
-        file_extension: '.nc'
-        classname: tsdat.io.filehandlers.NetCdfHandler
+        file_extension: ".nc"
+        classname: tsdat.io.handlers.NetCdfHandler
       csv:
-        file_extension: '.csv'
-        classname: tsdat.io.filehandlers.CsvHandler
+        file_extension: ".csv"
+        classname: tsdat.io.handlers.CsvHandler

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,7 +33,7 @@ def dataset():
 
 @pytest.fixture(scope="session", autouse=True)
 def raw_dataset():
-    from tsdat.io.filehandlers import CsvHandler
+    from tsdat.io.handlers import CsvHandler
 
     return CsvHandler().read(NON_MONOTONIC_CSV)
 

--- a/tsdat/__init__.py
+++ b/tsdat/__init__.py
@@ -21,8 +21,8 @@ from tsdat.io import (
     AwsStorage,
     S3Path,
     FilesystemStorage,
-    AbstractFileHandler,
-    FileHandler,
+    DataHandler,
+    HandlerRegistry,
     CsvHandler,
     NetCdfHandler,
 )

--- a/tsdat/io/__init__.py
+++ b/tsdat/io/__init__.py
@@ -9,9 +9,9 @@ uses to manage I/O for the pipeline.  Specifically, it includes:
  We warmly welcome community contribututions to increase the list of
  supported FileHandlers and Storage destinations.
 """
-from .filehandlers import (
-    AbstractFileHandler,
-    FileHandler,
+from .handlers import (
+    DataHandler,
+    HandlerRegistry,
     CsvHandler,
     NetCdfHandler,
 )

--- a/tsdat/io/filehandlers/__init__.py
+++ b/tsdat/io/filehandlers/__init__.py
@@ -1,8 +1,0 @@
-"""This module contains the File Handlers that come packaged with tsdat in
-addition to methods for registering new File Handler objects."""
-from .file_handlers import AbstractFileHandler
-from .file_handlers import FileHandler
-
-# These imports register default file handlers
-from .csv_handler import CsvHandler
-from .netcdf_handler import NetCdfHandler

--- a/tsdat/io/handlers/__init__.py
+++ b/tsdat/io/handlers/__init__.py
@@ -1,0 +1,7 @@
+"""This module contains the File Handlers that come packaged with tsdat in
+addition to methods for registering new File Handler objects."""
+from .handlers import DataHandler
+from .handlers import HandlerRegistry
+
+from .csv import CsvHandler
+from .netcdf import NetCdfHandler

--- a/tsdat/io/handlers/csv.py
+++ b/tsdat/io/handlers/csv.py
@@ -4,10 +4,10 @@ import pandas as pd
 import xarray as xr
 from tsdat.config import Config
 from tsdat.utils import DSUtil
-from .file_handlers import AbstractFileHandler
+from .handlers import DataHandler
 
 
-class CsvHandler(AbstractFileHandler):
+class CsvHandler(DataHandler):
     """FileHandler to read from and write to CSV files. Takes a number of
     parameters that are passed in from the storage config file. Parameters
     specified in the config file should follow the following example:

--- a/tsdat/io/handlers/handlers.py
+++ b/tsdat/io/handlers/handlers.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Literal, Union
 from tsdat.config import Config
 
 
-class AbstractFileHandler:
+class DataHandler:
     """Abstract class to define methods required by all FileHandlers. Classes
     derived from AbstractFileHandler should implement one or more of the
     following methods:
@@ -49,12 +49,12 @@ class AbstractFileHandler:
         pass
 
 
-class FileHandler:
+class HandlerRegistry:
     """Class to provide methods to read and write files with a variety of
     extensions."""
 
-    READERS: Dict[str, AbstractFileHandler] = None
-    WRITERS: Dict[str, AbstractFileHandler] = None
+    READERS: Dict[str, DataHandler] = None
+    WRITERS: Dict[str, DataHandler] = None
 
     def __init__(self) -> None:
         self.READERS = dict()
@@ -62,7 +62,7 @@ class FileHandler:
 
     def _get_handler(
         self, filename: str, method: Literal["read", "write"]
-    ) -> AbstractFileHandler:
+    ) -> DataHandler:
         """------------------------------------------------------------------------------------
         Given the filepath of the file to read or write and the FileHandler method to apply to
         the filepath, this method determines which previously-registered FileHandler should be
@@ -134,7 +134,7 @@ class FileHandler:
         self,
         method: Literal["read", "write"],
         patterns: Union[str, List[str]],
-        handler: AbstractFileHandler,
+        handler: DataHandler,
     ):
         """------------------------------------------------------------------------------------
         Method to register a FileHandler for reading from or writing to files matching one or

--- a/tsdat/io/handlers/netcdf.py
+++ b/tsdat/io/handlers/netcdf.py
@@ -2,10 +2,10 @@ import numpy as np
 import xarray as xr
 from tsdat.config import Config
 
-from .file_handlers import AbstractFileHandler
+from .handlers import DataHandler
 
 
-class NetCdfHandler(AbstractFileHandler):
+class NetCdfHandler(DataHandler):
     """FileHandler to read from and write to netCDF files. Takes a number of
     parameters that are passed in from the storage config file. Parameters
     specified in the config file should follow the following example:

--- a/tsdat/io/storage.py
+++ b/tsdat/io/storage.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import List, Union, Any, Dict
 
 from tsdat.config.utils import instantiate_handler, configure_yaml
-from tsdat.io import FileHandler
+from tsdat.io import HandlerRegistry
 from tsdat.utils import DSUtil
 
 
@@ -36,7 +36,7 @@ class DatastreamStorage(abc.ABC):
     default_file_type = None
 
     # Object to hold filehandlers registered for this storage object.
-    filehandler = FileHandler()
+    handlers = HandlerRegistry()
 
     # Stores the map of file types to filter functions that will
     # be loaded from the storage config file and is used to
@@ -77,7 +77,7 @@ class DatastreamStorage(abc.ABC):
         input_handlers = storage_dict.get("file_handlers", {}).get("input", {})
         for handler_dict in input_handlers.values():
             handler = instantiate_handler(handler_desc=handler_dict)
-            storage.filehandler.register_file_handler(
+            storage.handlers.register_file_handler(
                 "read", handler_dict["file_pattern"], handler
             )
 
@@ -89,7 +89,7 @@ class DatastreamStorage(abc.ABC):
 
             # First register the writers
             handler = instantiate_handler(handler_desc=handler_dict)
-            storage.filehandler.register_file_handler("write", file_pattern, handler)
+            storage.handlers.register_file_handler("write", file_pattern, handler)
 
             # Now register the file patterns for finding files in the store
             regex = re.compile(file_pattern)
@@ -226,7 +226,7 @@ class DatastreamStorage(abc.ABC):
                     dataset, file_extension=file_extension
                 )
                 with self.tmp.get_temp_filepath(dataset_filename) as tmp_path:
-                    self.filehandler.write(dataset, tmp_path)
+                    self.handlers.write(dataset, tmp_path)
                     saved_paths.append(self.save_local_path(tmp_path, new_filename))
 
         else:

--- a/tsdat/pipeline/ingest_pipeline.py
+++ b/tsdat/pipeline/ingest_pipeline.py
@@ -1,7 +1,6 @@
 import warnings
 import xarray as xr
 from typing import Dict, List, Union
-from tsdat.io.filehandlers import FileHandler
 from tsdat.qc import QualityManagement
 from tsdat.utils import DSUtil
 from .pipeline import Pipeline
@@ -159,7 +158,7 @@ class IngestPipeline(Pipeline):
 
             # read the raw file into a dataset
             with self.storage.tmp.fetch(file_path) as tmp_path:
-                dataset = self.storage.filehandler.read(tmp_path)
+                dataset = self.storage.handlers.read(tmp_path)
 
                 # Don't use dataset if no FileHandler is registered for it
                 if dataset is not None:

--- a/tsdat/pipeline/pipeline.py
+++ b/tsdat/pipeline/pipeline.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Union
 
 from tsdat.utils import DSUtil
 from tsdat.config import Config, DatasetDefinition, VariableDefinition
-from tsdat.io import DatastreamStorage, FileHandler
+from tsdat.io import DatastreamStorage
 
 
 class Pipeline(abc.ABC):
@@ -235,7 +235,7 @@ class Pipeline(abc.ABC):
             datastream_name, f"{start_date}.{start_time}"
         ) as netcdf_file:
             if netcdf_file:
-                prev_dataset = self.storage.filehandler.read(
+                prev_dataset = self.storage.handlers.read(
                     netcdf_file, config=self.config
                 )
 
@@ -380,7 +380,7 @@ class Pipeline(abc.ABC):
         with self.storage.tmp.fetch(saved_paths[0]) as tmp_path:
             # Need to read using the FileHandler registered for writing output because
             # we are re-opening the output dataset
-            handler = self.storage.filehandler._get_handler(tmp_path, "write")
+            handler = self.storage.handlers._get_handler(tmp_path, "write")
             reopened_dataset = handler.read(tmp_path)
 
         return reopened_dataset


### PR DESCRIPTION
Rename `FileHandler` objects so as to start moving away from being strictly file-based. 