### PR TITLE
Add ways to get in touch

### DIFF
--- a/docs/source/collaboration.rst
+++ b/docs/source/collaboration.rst
@@ -1,7 +1,9 @@
+.. _start a discussion on GitHub: https://github.com/tsdat/tsdat/discussions
+
 .. _collaboration:
 
 Collaboration
-#################
+#############
 
 tsdat is an open-source project that is still in its infancy. We 
 enthusiastically welcome any feedback that helps us track down
@@ -10,24 +12,32 @@ in the form of new File Handlers, Quality Checkers, Quality Handlers,
 Converters, and Pipeline definitions.
 
 Issues
-----------------
+------
+
 Questions, feature requests, and bug reports for tsdat should be submitted to the GitHub Issues Page.
 The GitHub online forums are managed by the tsdat development team and users.
 
-`Submit tsdat Issue <https://github.com/tsdat/tsdat/issues>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Submit an issue <https://github.com/tsdat/tsdat/issues>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Contributing
-----------------
+------------
+
 Software developers interested in contributing to the tsdat open-source software are encouraged to use GitHub
 to create a `Fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_ of the repository
 into their GitHub user account.  To include your additions to the tsdat code, please submit a 
 `pull request <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request>`_ of the modified repository.
 Once reviewed by the tsdat development team, pull requests will be merged into the tsdat master branch,
-and included in future releases.  Software developers - both within the tsdat development team and external collaborators -
-are expected to follow standard practices to document and test new code.
+and included in future releases.
 
 
-`Submit tsdat Pull Request <https://github.com/tsdat/tsdat/pulls>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Submit a pull request <https://github.com/tsdat/tsdat/pulls>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+
+Get in Touch
+------------
+
+We would love to hear from you! If you have any feedback, questions, ideas, or anything 
+else you would like to share with us, please feel free to `start a discussion on GitHub`_
+or shoot us an email at tsdat@pnnl.gov and we will get back to you as soon as possible.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,7 @@
 .. _Xarray: http://xarray.pydata.org/en/stable/
 .. _netCDF: https://www.unidata.ucar.edu/software/netcdf/
 .. _ARM program: https://arm.gov
+.. _start a discussion on GitHub: https://github.com/tsdat/tsdat/discussions
 
 
 .. toctree::
@@ -77,3 +78,12 @@ following data standards and best practices when building data pipelines so
 that your data is clean, easy to understand, more accessible, and ultimately 
 more valuable to your data users. 
 
+.. _contact:
+
+Get in Touch
+************
+
+We would love to hear from you! If you have any feedback, questions, ideas, or
+anything else you would like to share with us, please feel free to
+`start a discussion on GitHub`_ or shoot us an email at tsdat@pnnl.gov and we will
+get back to you as soon as possible.


### PR DESCRIPTION
Our documentation did not include our email address or a link to our GitHub discussions page. We are including these now to expand our reach.