### PR TITLE
Use patterns as keys for data readers

### DIFF
--- a/.vscode/schema/dataset-schema.json
+++ b/.vscode/schema/dataset-schema.json
@@ -1,10 +1,16 @@
 {
     "title": "DatasetConfig",
-    "description": "Defines the core output dataset structure, including coordinate variables, data\nvariables, and metadata attributes. Quality check variables are not included in this\nstructure.",
+    "description": "---------------------------------------------------------------------------------\nClass defining the structure and metadata of the dataset produced by a tsdat\npipeline.\n\nAlso provides methods to support yaml parsing and validation, including generation\nof json schema.\n\nArgs:\n    attrs (GlobalAttributes): Attributes that pertain to the dataset as a whole.\n    coords (Dict[str, Coordinate]): The dataset's coordinate variables.\n    data_vars (Dict[str, Variable]): The dataset's data variables.\n\n---------------------------------------------------------------------------------",
     "type": "object",
     "properties": {
         "attrs": {
-            "$ref": "#/definitions/GlobalAttributes"
+            "title": "Attrs",
+            "description": "Attributes that pertain to the dataset as a whole (as opposed to attributes that are specific to individual variables.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/GlobalAttributes"
+                }
+            ]
         },
         "coords": {
             "title": "Coords",
@@ -81,7 +87,7 @@
                 },
                 "location_id": {
                     "title": "Location Id",
-                    "description": "A label or acroynm for the location where the data were obtained from. Only lowercase alphanumeric characters and '_' are allowed.",
+                    "description": "A label or acronym for the location where the data were obtained from. Only lowercase alphanumeric characters and '_' are allowed.",
                     "minLength": 3,
                     "pattern": "^[a-z0-9_]+$",
                     "type": "string"
@@ -104,7 +110,7 @@
                     "title": "Temporal",
                     "description": "An optional string which describes the temporal resolution of the data (if it spaced in regular intervals). This string should be formated as a number followed by a unit of measurement, e.g., '10m' would indicate the data is sampled every ten minutes. Only lowercase alphanumeric characters are allowed.",
                     "minLength": 2,
-                    "pattern": "^[0-9]+[a-z]+$",
+                    "pattern": "^[0-9]+[a-zA-Z]+$",
                     "type": "string"
                 },
                 "data_level": {

--- a/.vscode/schema/pipeline-schema.json
+++ b/.vscode/schema/pipeline-schema.json
@@ -1,6 +1,6 @@
 {
     "title": "PipelineConfig",
-    "description": "------------------------------------------------------------------------------------\nClass used read in the yaml pipeline config file and to generate its json schema for\nearly validation of its properties.\n\nThis class also provides a method to instantiate a subclass of tsdat.pipeline.Pipeline\nfrom the parsed pipeline configuration file.\n------------------------------------------------------------------------------------",
+    "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for tsdat pipelines. This class will\nultimately be converted into a tsdat.pipeline.base.Pipeline subclass for use in\ntsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.pipeline.base.Pipeline subclass from a parsed configuration\nfile.\n\nArgs:\n    classname (str): The dotted module path to the pipeline that the specified\n    configurations should apply to. To use the built-in IngestPipeline, for example,\n    you would set 'tsdat.pipeline.pipelines.IngestPipeline' as the classname.\n    triggers (List[Pattern[str]]): A list of regex patterns that should trigger this\n    pipeline when matched with an input key.\n    retriever (Union[Overrideable[RetrieverConfig], RetrieverConfig]): Either the\n    path to the retriever configuration yaml file and any overrides that should be\n    applied, or the retriever configurations themselves.\n    dataset (Union[Overrideable[DatasetConfig], DatasetConfig]): Either the path to\n    the dataset configuration yaml file and any overrides that should be applied, or\n    the dataset configurations themselves.\n    quality (Union[Overrideable[QualityConfig], QualityConfig]): Either the path to\n    the quality configuration yaml file and any overrides that should be applied, or\n    the dataset configurations themselves.\n    storage (Union[Overrideable[StorageConfig], StorageConfig]): Either the path to\n    the storage configuration yaml file and any overrides that should be applied, or\n    the storage configurations themselves.\n\n---------------------------------------------------------------------------------",
     "type": "object",
     "properties": {
         "classname": {
@@ -22,20 +22,6 @@
                 "type": "string",
                 "format": "regex"
             }
-        },
-        "settings": {
-            "title": "Settings",
-            "default": {
-                "validate_retriever_config": true,
-                "validate_dataset_config": true,
-                "validate_quality_config": true,
-                "validate_storage_config": true
-            },
-            "allOf": [
-                {
-                    "$ref": "#/definitions/ConfigSettings"
-                }
-            ]
         },
         "retriever": {
             "title": "Retriever",
@@ -94,50 +80,7 @@
         "quality",
         "storage"
     ],
-    "additionalProperties": false,
     "definitions": {
-        "ConfigSettings": {
-            "title": "ConfigSettings",
-            "description": "Base class for settings, allowing values to be overridden by environment variables.\n\nThis is useful in production for secrets you do not wish to save in code, it plays nicely with docker(-compose),\nHeroku and any 12 factor app design.",
-            "type": "object",
-            "properties": {
-                "validate_retriever_config": {
-                    "title": "Validate Retriever Config",
-                    "default": true,
-                    "env_names": [
-                        "validate_retriever_config"
-                    ],
-                    "type": "boolean"
-                },
-                "validate_dataset_config": {
-                    "title": "Validate Dataset Config",
-                    "description": "Validate the dataset configuration file after any overrides have been merged. Disabling validation is generally 10-30x faster, but comes with some risks and can easily lead to buggy behavior if you are not careful. For example. the dataset configuration model uses validators to set defaults for the 'datastream' attribute based on other global attributes that are set. The 'datastream' attribute is used elsewhere in the pipeline as a label for the dataset, and is used by some storage classes to generate the filepath where the data should be saved. If you disable dataset configuration validation, THIS WILL NOT WORK, so you will need to take care to set the 'datastream' attribute manually in your config file directly. Because of the complicated nature of dataset configuration files, it is almost always better to leave validation ON.",
-                    "default": true,
-                    "env_names": [
-                        "validate_dataset_config"
-                    ],
-                    "type": "boolean"
-                },
-                "validate_quality_config": {
-                    "title": "Validate Quality Config",
-                    "description": "Validate the quality configuration file after any overrides have been merged. Disabling validation is generally 10-30x faster, but comes with some risks and can easily lead to buggy behavior if you are not careful. For example. the quality configuration model uses validators to set defaults for regex patterns in the registry/readers section. If you disable validation of the quality configuration file, then you must ensure that your regex patterns are set explicitly, as you will not be able to rely on the dynamic defaults.",
-                    "default": true,
-                    "env_names": [
-                        "validate_quality_config"
-                    ],
-                    "type": "boolean"
-                },
-                "validate_storage_config": {
-                    "title": "Validate Storage Config",
-                    "description": "Validate the storage configuration file after any overrides have been merged. Disabling validation is generally 10-30x faster, but comes with some risks and can easily lead to buggy behavior if you are not careful.",
-                    "default": true,
-                    "env_names": [
-                        "validate_storage_config"
-                    ],
-                    "type": "boolean"
-                }
-            }
-        },
         "Overrideable_RetrieverConfig_": {
             "title": "Overrideable[RetrieverConfig]",
             "type": "object",
@@ -172,13 +115,6 @@
                     "description": "Optional dictionary that will be passed to the Python class specified by 'classname' when it is instantiated. If the object is a tsdat class, then the parameters will typically be made accessible under the `params` property on an instance of the class. See the documentation for individual classes for more information.",
                     "default": {},
                     "type": "object"
-                },
-                "regex": {
-                    "title": "Regex",
-                    "description": "A regex pattern used to map input data keys (e.g., a file path or url passed as input from the pipeline runner) to the DataReader that should be used to read that resource. If there are multiple DataReader registered and an input data key would be matched by the regex pattern of multiple DataReaders, then only the DataReader corresponding with the first match will be used. Because of this, we recommend ordering your DataReaders from most specific pattern to least specific so that the most specific pattern will be matched first.",
-                    "default": "",
-                    "type": "string",
-                    "format": "regex"
                 }
             },
             "required": [
@@ -188,6 +124,7 @@
         },
         "RetrieverConfig": {
             "title": "RetrieverConfig",
+            "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for the tsdat retriever class. This\nclass will ultimately be converted into a tsdat.io.base.Retriever subclass for use\nin tsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.\n\nArgs:\n    classname (str): The dotted module path to the pipeline that the specified\n    configurations should apply to. To use the built-in IngestPipeline, for example,\n    you would set 'tsdat.pipeline.pipelines.IngestPipeline' as the classname.\n    readers (Dict[str, DataReaderConfig]): The DataReaders to use for reading input\n    data.\n\n---------------------------------------------------------------------------------",
             "type": "object",
             "properties": {
                 "classname": {
@@ -281,7 +218,7 @@
                 },
                 "location_id": {
                     "title": "Location Id",
-                    "description": "A label or acroynm for the location where the data were obtained from. Only lowercase alphanumeric characters and '_' are allowed.",
+                    "description": "A label or acronym for the location where the data were obtained from. Only lowercase alphanumeric characters and '_' are allowed.",
                     "minLength": 3,
                     "pattern": "^[a-z0-9_]+$",
                     "type": "string"
@@ -304,7 +241,7 @@
                     "title": "Temporal",
                     "description": "An optional string which describes the temporal resolution of the data (if it spaced in regular intervals). This string should be formated as a number followed by a unit of measurement, e.g., '10m' would indicate the data is sampled every ten minutes. Only lowercase alphanumeric characters are allowed.",
                     "minLength": 2,
-                    "pattern": "^[0-9]+[a-z]+$",
+                    "pattern": "^[0-9]+[a-zA-Z]+$",
                     "type": "string"
                 },
                 "data_level": {
@@ -510,11 +447,17 @@
         },
         "DatasetConfig": {
             "title": "DatasetConfig",
-            "description": "Defines the core output dataset structure, including coordinate variables, data\nvariables, and metadata attributes. Quality check variables are not included in this\nstructure.",
+            "description": "---------------------------------------------------------------------------------\nClass defining the structure and metadata of the dataset produced by a tsdat\npipeline.\n\nAlso provides methods to support yaml parsing and validation, including generation\nof json schema.\n\nArgs:\n    attrs (GlobalAttributes): Attributes that pertain to the dataset as a whole.\n    coords (Dict[str, Coordinate]): The dataset's coordinate variables.\n    data_vars (Dict[str, Variable]): The dataset's data variables.\n\n---------------------------------------------------------------------------------",
             "type": "object",
             "properties": {
                 "attrs": {
-                    "$ref": "#/definitions/GlobalAttributes"
+                    "title": "Attrs",
+                    "description": "Attributes that pertain to the dataset as a whole (as opposed to attributes that are specific to individual variables.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/GlobalAttributes"
+                        }
+                    ]
                 },
                 "coords": {
                     "title": "Coords",
@@ -656,10 +599,12 @@
                 "checker",
                 "handlers",
                 "apply_to"
-            ]
+            ],
+            "additionalProperties": false
         },
         "QualityConfig": {
             "title": "QualityConfig",
+            "description": "---------------------------------------------------------------------------------\nClass used to contain quality configuration parameters for tsdat pipelines. This\nclass will ultimately be converted into a tsdat.qc.base.QualityManagement class for\nuse in downstream tsdat pipeline code.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation.\n\nArgs:\n    managers (List[ManagerConfig]): A list of quality checks and controls that\n    should be applied.\n\n---------------------------------------------------------------------------------",
             "type": "object",
             "properties": {
                 "managers": {
@@ -673,7 +618,8 @@
             },
             "required": [
                 "managers"
-            ]
+            ],
+            "additionalProperties": false
         },
         "Overrideable_StorageConfig_": {
             "title": "Overrideable[StorageConfig]",
@@ -718,6 +664,7 @@
         },
         "StorageConfig": {
             "title": "StorageConfig",
+            "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for tsdat pipelines. This class will\nultimately be converted into a tsdat.pipeline.base.Pipeline subclass for use in\ntsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Storage subclass from a parsed configuration file.\n\nArgs:\n    classname (str): The dotted module path to the storage class that the specified\n    configurations should apply to. To use the built-in FileSystemStorage, for\n    example, you would set 'tsdat.io.storage.FileSystemStorage' as the classname.\n    handler (DataHandlerConfig): Config class that should be used for data I/O\n    within the storage area.\n\n---------------------------------------------------------------------------------",
             "type": "object",
             "properties": {
                 "classname": {

--- a/.vscode/schema/quality-schema.json
+++ b/.vscode/schema/quality-schema.json
@@ -1,5 +1,6 @@
 {
     "title": "QualityConfig",
+    "description": "---------------------------------------------------------------------------------\nClass used to contain quality configuration parameters for tsdat pipelines. This\nclass will ultimately be converted into a tsdat.qc.base.QualityManagement class for\nuse in downstream tsdat pipeline code.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation.\n\nArgs:\n    managers (List[ManagerConfig]): A list of quality checks and controls that\n    should be applied.\n\n---------------------------------------------------------------------------------",
     "type": "object",
     "properties": {
         "managers": {
@@ -14,6 +15,7 @@
     "required": [
         "managers"
     ],
+    "additionalProperties": false,
     "definitions": {
         "CheckerConfig": {
             "title": "CheckerConfig",
@@ -107,7 +109,8 @@
                 "checker",
                 "handlers",
                 "apply_to"
-            ]
+            ],
+            "additionalProperties": false
         }
     }
 }

--- a/.vscode/schema/retriever-schema.json
+++ b/.vscode/schema/retriever-schema.json
@@ -1,5 +1,6 @@
 {
     "title": "RetrieverConfig",
+    "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for the tsdat retriever class. This\nclass will ultimately be converted into a tsdat.io.base.Retriever subclass for use\nin tsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.\n\nArgs:\n    classname (str): The dotted module path to the pipeline that the specified\n    configurations should apply to. To use the built-in IngestPipeline, for example,\n    you would set 'tsdat.pipeline.pipelines.IngestPipeline' as the classname.\n    readers (Dict[str, DataReaderConfig]): The DataReaders to use for reading input\n    data.\n\n---------------------------------------------------------------------------------",
     "type": "object",
     "properties": {
         "classname": {
@@ -40,13 +41,6 @@
                     "description": "Optional dictionary that will be passed to the Python class specified by 'classname' when it is instantiated. If the object is a tsdat class, then the parameters will typically be made accessible under the `params` property on an instance of the class. See the documentation for individual classes for more information.",
                     "default": {},
                     "type": "object"
-                },
-                "regex": {
-                    "title": "Regex",
-                    "description": "A regex pattern used to map input data keys (e.g., a file path or url passed as input from the pipeline runner) to the DataReader that should be used to read that resource. If there are multiple DataReader registered and an input data key would be matched by the regex pattern of multiple DataReaders, then only the DataReader corresponding with the first match will be used. Because of this, we recommend ordering your DataReaders from most specific pattern to least specific so that the most specific pattern will be matched first.",
-                    "default": "",
-                    "type": "string",
-                    "format": "regex"
                 }
             },
             "required": [

--- a/.vscode/schema/storage-schema.json
+++ b/.vscode/schema/storage-schema.json
@@ -1,5 +1,6 @@
 {
     "title": "StorageConfig",
+    "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for tsdat pipelines. This class will\nultimately be converted into a tsdat.pipeline.base.Pipeline subclass for use in\ntsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Storage subclass from a parsed configuration file.\n\nArgs:\n    classname (str): The dotted module path to the storage class that the specified\n    configurations should apply to. To use the built-in FileSystemStorage, for\n    example, you would set 'tsdat.io.storage.FileSystemStorage' as the classname.\n    handler (DataHandlerConfig): Config class that should be used for data I/O\n    within the storage area.\n\n---------------------------------------------------------------------------------",
     "type": "object",
     "properties": {
         "classname": {

--- a/test/config/test_retriever_config.py
+++ b/test/config/test_retriever_config.py
@@ -13,7 +13,6 @@ def test_reader_config_produces_expected_dict():
     expected_dict: Dict[str, Any] = {
         "classname": "tsdat.io.handlers.readers.NetCDFReader",
         "parameters": {},
-        "regex": "",  # Dynamic default to .* is done at the next level up
     }
     reader_model = DataReaderConfig(**reader_dict)
     reader_dict = reader_model.dict()
@@ -24,7 +23,6 @@ def test_reader_config_validates_required_properties():
     reader_dict: Dict[str, Any] = {"regex": []}
     expected_error_msgs = [
         "\nclassname\n  field required",
-        "\nregex\n  str type expected",
     ]
     with pytest.raises(ValidationError) as error:
         DataReaderConfig(**reader_dict)
@@ -34,26 +32,29 @@ def test_reader_config_validates_required_properties():
         assert expected_msg in actual_msg
 
 
-def test_retriever_config_validates_required_properties():
+# def test_retriever_config_validates_required_properties():
 
-    kwargs: Dict[str, Any] = {
-        "classname": "tsdat.io.retrievers.DefaultRetriever",
-        "parameters": {},
-        "readers": {
-            "csv": {"classname": "tsdat.io.readers.CSVReader", "regex": r".*\.csv"},
-            "netcdf": {
-                "classname": "tsdat.io.readers.NetCDFReader",
-            },
-        },
-    }
-    expected_msg = (
-        "If len(readers) > 1 then all readers should define a 'regex' pattern"
-    )
-    with pytest.raises(ValidationError) as error:
-        RetrieverConfig(**kwargs)
+#     kwargs: Dict[str, Any] = {
+#         "classname": "tsdat.io.retrievers.DefaultRetriever",
+#         "parameters": {},
+#         "readers": {
+#             re.compile(r".*\.csv"): {
+#                 "classname": "tsdat.io.readers.CSVReader",
+#                 "regex": r".*\.csv",
+#             },
+#             re.compile(r".*\.nc"): {
+#                 "classname": "tsdat.io.readers.NetCDFReader",
+#             },
+#         },
+#     }
+#     expected_msg = (
+#         "If len(readers) > 1 then all readers should define a 'regex' pattern"
+#     )
+#     with pytest.raises(ValidationError) as error:
+#         RetrieverConfig(**kwargs)
 
-    actual_msg = get_pydantic_error_message(error)
-    assert expected_msg in actual_msg
+#     actual_msg = get_pydantic_error_message(error)
+#     assert expected_msg in actual_msg
 
 
 def test_retriever_config_can_be_created_without_errors():
@@ -62,21 +63,17 @@ def test_retriever_config_can_be_created_without_errors():
         "classname": "tsdat.io.retrievers.DefaultRetriever",
         "parameters": {},
         "readers": {
-            "csv": {"classname": "tsdat.io.readers.CSVReader"},
+            re.compile(r".*\.csv"): {"classname": "tsdat.io.readers.CSVReader"},
         },
     }
-    retriever_config = RetrieverConfig(**kwargs)
-    assert retriever_config.readers["csv"].regex == re.compile(".*")  # type: ignore
+    RetrieverConfig(**kwargs)
 
     kwargs: Dict[str, Any] = {
         "classname": "tsdat.io.retrievers.DefaultRetriever",
         "parameters": {},
         "readers": {
-            "csv": {"classname": "tsdat.io.readers.CSVReader", "regex": r".*\.csv"},
-            "netcdf": {
-                "classname": "tsdat.io.readers.NetCDFReader",
-                "regex": r".*\.nc",
-            },
+            re.compile(r".*\.csv"): {"classname": "tsdat.io.readers.CSVReader"},
+            re.compile(r".*\.nc"): {"classname": "tsdat.io.readers.NetCDFReader"},
         },
     }
-    retriever_config = RetrieverConfig(**kwargs)
+    RetrieverConfig(**kwargs)

--- a/test/config/yaml/retriever.yaml
+++ b/test/config/yaml/retriever.yaml
@@ -2,7 +2,7 @@ classname: tsdat.io.retrievers.DefaultRetriever
 parameters: {}
 
 readers:
-  csv:
+  .*\.csv:
     classname: tsdat.io.readers.CSVReader
 
 # IDEA: Add the coords / data vars structure to the config object & generate schema

--- a/tsdat/config/retriever.py
+++ b/tsdat/config/retriever.py
@@ -1,25 +1,24 @@
-import re
 from typing import Dict, Pattern
-from pydantic import Field, validator, Extra
-from pydantic.fields import ModelField
+from pydantic import Extra
 from .utils import ParameterizedConfigClass, YamlModel
 
 __all__ = ["RetrieverConfig"]
 
 
 class DataReaderConfig(ParameterizedConfigClass):
+    pass
     # HACK: Can't do Pattern[str]: https://github.com/samuelcolvin/pydantic/issues/2636
-    regex: Pattern = Field(  # type: ignore
-        "",
-        description="A regex pattern used to map input data keys (e.g., a file path or"
-        " url passed as input from the pipeline runner) to the DataReader that should"
-        " be used to read that resource. If there are multiple DataReader registered"
-        " and an input data key would be matched by the regex pattern of multiple"
-        " DataReaders, then only the DataReader corresponding with the first match will"
-        " be used. Because of this, we recommend ordering your DataReaders from most"
-        " specific pattern to least specific so that the most specific pattern will be"
-        " matched first.",
-    )
+    # regex: Pattern = Field(  # type: ignore
+    #     "",
+    #     description="A regex pattern used to map input data keys (e.g., a file path or"
+    #     " url passed as input from the pipeline runner) to the DataReader that should"
+    #     " be used to read that resource. If there are multiple DataReader registered"
+    #     " and an input data key would be matched by the regex pattern of multiple"
+    #     " DataReaders, then only the DataReader corresponding with the first match will"
+    #     " be used. Because of this, we recommend ordering your DataReaders from most"
+    #     " specific pattern to least specific so that the most specific pattern will be"
+    #     " matched first.",
+    # )
 
 
 class RetrieverConfig(ParameterizedConfigClass, YamlModel, extra=Extra.allow):
@@ -41,24 +40,4 @@ class RetrieverConfig(ParameterizedConfigClass, YamlModel, extra=Extra.allow):
 
     ---------------------------------------------------------------------------------"""
 
-    readers: Dict[str, DataReaderConfig]
-
-    @validator("readers")
-    @classmethod
-    def validate_regex_patterns(
-        cls, readers: Dict[str, DataReaderConfig], field: ModelField
-    ) -> Dict[str, DataReaderConfig]:
-
-        if len(readers) == 1:
-            reader = list(readers.values())[0]
-
-            if not reader.regex:  # type: ignore
-                reader.regex = re.compile(r".*")  # type: ignore
-
-        # Ensure handlers define regex patterns if len > 1.
-        elif any(not dh.regex for dh in readers.values()):  # type: ignore
-            raise ValueError(
-                f"If len({field.name}) > 1 then all readers should define a 'regex'"
-                " pattern."
-            )
-        return readers
+    readers: Dict[Pattern, DataReaderConfig]  # type: ignore

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -1,4 +1,3 @@
-import re
 import tempfile
 import contextlib
 import xarray as xr
@@ -66,10 +65,6 @@ class DataReader(ParameterizedClass, ABC):
 
     ---------------------------------------------------------------------------------"""
 
-    # HACK: Can't do Pattern[str] yet
-    regex: Pattern = re.compile(r".*")  # type: ignore
-    """The regex pattern associated with the DataReader. Defaults to `.*`."""
-
     @abstractmethod
     def read(self, input_key: str) -> Union[xr.Dataset, Dict[str, xr.Dataset]]:
         """-----------------------------------------------------------------------------
@@ -92,9 +87,6 @@ class DataReader(ParameterizedClass, ABC):
 
         -----------------------------------------------------------------------------"""
         ...
-
-    def matches(self, key: str) -> bool:
-        return bool(self.regex.match(key))  # type: ignore
 
 
 class DataWriter(ParameterizedClass, ABC):

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -191,7 +191,7 @@ class Retriever(ParameterizedClass, ABC):
 
     ---------------------------------------------------------------------------------"""
 
-    readers: Dict[str, Any]
+    readers: Dict[Pattern, Any]  # type: ignore
     """Mapping of readers that should be used to read data given input keys."""
 
     @abstractmethod

--- a/tsdat/io/retrievers.py
+++ b/tsdat/io/retrievers.py
@@ -4,7 +4,7 @@
 import logging
 import xarray as xr
 from pydantic import BaseModel, Extra
-from typing import Any, Dict, List, Pattern
+from typing import Any, Dict, List, Pattern, cast
 from ..config.dataset import DatasetConfig
 from .base import Retriever, DataReader, DataConverter
 
@@ -52,7 +52,7 @@ class DefaultRetriever(Retriever):
 
     parameters: Parameters = Parameters()
 
-    readers: Dict[str, DataReader]
+    readers: Dict[Pattern, DataReader]  # type: ignore
     """A dictionary of DataReaders that should be used to read data provided an input
     key."""
 
@@ -97,8 +97,9 @@ class DefaultRetriever(Retriever):
     def _match_inputs(self, input_keys: List[str]) -> Dict[str, DataReader]:
         input_reader_mapping: Dict[str, DataReader] = {}
         for input_key in input_keys:
-            for reader in self.readers.values():
-                if reader.matches(input_key):
+            for regex, reader in self.readers.items():  # type: ignore
+                regex = cast(Pattern[str], regex)
+                if regex.match(input_key):
                     input_reader_mapping[input_key] = reader
                     break
         return input_reader_mapping


### PR DESCRIPTION
This PR removes the `regex` property on `DataReaders` and makes it the dictionary key for the `readers` section in the retrieval configuration file, and associated python classes. This change is consistent with the rest of the retrieval configuration file.