### PR TITLE
Fix output units warning

### DIFF
--- a/tsdat/io/converters.py
+++ b/tsdat/io/converters.py
@@ -66,11 +66,12 @@ class UnitsConverter(DataConverter):
             or output_units == "unitless"
             or input_units == output_units
         ):
-            logger.warning(
-                "Output units for variable %s could not be found. Please ensure these"
-                " are set in the dataset configuration file for the specified variable.",
-                variable_name,
-            )
+            if not output_units:
+                logger.warning(
+                    "Output units for variable %s could not be found. Please ensure these"
+                    " are set in the dataset configuration file for the specified variable.",
+                    variable_name,
+                )
             return dataset
 
         data: NDArray[Any] = act.utils.data_utils.convert_units(  # type: ignore


### PR DESCRIPTION
Only warn that output units are not provided if output units are, indeed, not provided.