### PR TITLE
Expand `RetrieverConfig`, update schema

### DIFF
--- a/.vscode/schema/pipeline-schema.json
+++ b/.vscode/schema/pipeline-schema.json
@@ -122,9 +122,54 @@
             ],
             "additionalProperties": false
         },
+        "DataConverterConfig": {
+            "title": "DataConverterConfig",
+            "type": "object",
+            "properties": {
+                "classname": {
+                    "title": "Classname",
+                    "description": "The import path to the Python class that should be used, e.g., if your import statement looks like `from foo.bar import Baz`, then your classname would be `foo.bar.Baz`.",
+                    "type": "string"
+                },
+                "parameters": {
+                    "title": "Parameters",
+                    "description": "Optional dictionary that will be passed to the Python class specified by 'classname' when it is instantiated. If the object is a tsdat class, then the parameters will typically be made accessible under the `params` property on an instance of the class. See the documentation for individual classes for more information.",
+                    "default": {},
+                    "type": "object"
+                }
+            },
+            "required": [
+                "classname"
+            ]
+        },
+        "RetrievedVariableConfig": {
+            "title": "RetrievedVariableConfig",
+            "description": "Specifies how the variable should be retrieved from the raw dataset and the\npreprocessing steps (i.e. DataConverters) that should be applied.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "description": "The exact name of the variable in the raw dataset returned by the DataReader.",
+                    "type": "string"
+                },
+                "data_converters": {
+                    "title": "Data Converters",
+                    "description": "A list of DataConverters to run for this variable. Common choices include the tsdat UnitsConverter (classname: 'tsdat.io.converters.UnitsConverter') to convert the variable's data from its input units to specified output units, and the tsdat StringToDatetime converter (classname: 'tsdat.io.converters.StringToDatetime'), which takes dates/times formatted as strings and converts them into a datetime64 object that can be used throughout the rest of the pipeline. This property is optional and defaults to [].",
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DataConverterConfig"
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
         "RetrieverConfig": {
             "title": "RetrieverConfig",
-            "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for the tsdat retriever class. This\nclass will ultimately be converted into a tsdat.io.base.Retriever subclass for use\nin tsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.\n\nArgs:\n    classname (str): The dotted module path to the pipeline that the specified\n    configurations should apply to. To use the built-in IngestPipeline, for example,\n    you would set 'tsdat.pipeline.pipelines.IngestPipeline' as the classname.\n    readers (Dict[str, DataReaderConfig]): The DataReaders to use for reading input\n    data.\n\n---------------------------------------------------------------------------------",
+            "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for the tsdat retriever class. This\nclass will ultimately be converted into a tsdat.io.base.Retriever subclass for use\nin tsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.\n\n---------------------------------------------------------------------------------",
             "type": "object",
             "properties": {
                 "classname": {
@@ -140,9 +185,48 @@
                 },
                 "readers": {
                     "title": "Readers",
+                    "description": "A dictionary mapping regex patterns to DataReaders that should be used to read the input data. For each input given to the Retriever, the mapping will be used to determine which DataReader to use. The patterns will be searched in the order they are defined and the DataReader corresponding with the first pattern that matches the input key will be used.",
                     "type": "object",
                     "additionalProperties": {
                         "$ref": "#/definitions/DataReaderConfig"
+                    }
+                },
+                "coords": {
+                    "title": "Coords",
+                    "description": "A dictionary mapping output coordinate variable names to the retrieval rules and preprocessing actions (i.e. DataConverters) that should be applied to each retrieved coordinate variable.",
+                    "default": {},
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/definitions/RetrievedVariableConfig"
+                                }
+                            },
+                            {
+                                "$ref": "#/definitions/RetrievedVariableConfig"
+                            }
+                        ]
+                    }
+                },
+                "data_vars": {
+                    "title": "Data Vars",
+                    "description": "A dictionary mapping output data_variable variable names to the retrieval rules and preprocessing actions (i.e. DataConverters) that should be applied to each retrieved coordinate variable.",
+                    "default": {},
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/definitions/RetrievedVariableConfig"
+                                }
+                            },
+                            {
+                                "$ref": "#/definitions/RetrievedVariableConfig"
+                            }
+                        ]
                     }
                 }
             },

--- a/.vscode/schema/pipeline-schema.json
+++ b/.vscode/schema/pipeline-schema.json
@@ -164,8 +164,7 @@
             },
             "required": [
                 "name"
-            ],
-            "additionalProperties": false
+            ]
         },
         "RetrieverConfig": {
             "title": "RetrieverConfig",

--- a/.vscode/schema/retriever-schema.json
+++ b/.vscode/schema/retriever-schema.json
@@ -1,6 +1,6 @@
 {
     "title": "RetrieverConfig",
-    "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for the tsdat retriever class. This\nclass will ultimately be converted into a tsdat.io.base.Retriever subclass for use\nin tsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.\n\nArgs:\n    classname (str): The dotted module path to the pipeline that the specified\n    configurations should apply to. To use the built-in IngestPipeline, for example,\n    you would set 'tsdat.pipeline.pipelines.IngestPipeline' as the classname.\n    readers (Dict[str, DataReaderConfig]): The DataReaders to use for reading input\n    data.\n\n---------------------------------------------------------------------------------",
+    "description": "---------------------------------------------------------------------------------\nClass used to contain configuration parameters for the tsdat retriever class. This\nclass will ultimately be converted into a tsdat.io.base.Retriever subclass for use\nin tsdat pipelines.\n\nProvides methods to support yaml parsing and validation, including the generation of\njson schema for immediate validation. This class also provides a method to\ninstantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.\n\n---------------------------------------------------------------------------------",
     "type": "object",
     "properties": {
         "classname": {
@@ -16,9 +16,48 @@
         },
         "readers": {
             "title": "Readers",
+            "description": "A dictionary mapping regex patterns to DataReaders that should be used to read the input data. For each input given to the Retriever, the mapping will be used to determine which DataReader to use. The patterns will be searched in the order they are defined and the DataReader corresponding with the first pattern that matches the input key will be used.",
             "type": "object",
             "additionalProperties": {
                 "$ref": "#/definitions/DataReaderConfig"
+            }
+        },
+        "coords": {
+            "title": "Coords",
+            "description": "A dictionary mapping output coordinate variable names to the retrieval rules and preprocessing actions (i.e. DataConverters) that should be applied to each retrieved coordinate variable.",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/RetrievedVariableConfig"
+                        }
+                    },
+                    {
+                        "$ref": "#/definitions/RetrievedVariableConfig"
+                    }
+                ]
+            }
+        },
+        "data_vars": {
+            "title": "Data Vars",
+            "description": "A dictionary mapping output data_variable variable names to the retrieval rules and preprocessing actions (i.e. DataConverters) that should be applied to each retrieved coordinate variable.",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/RetrievedVariableConfig"
+                        }
+                    },
+                    {
+                        "$ref": "#/definitions/RetrievedVariableConfig"
+                    }
+                ]
             }
         }
     },
@@ -45,6 +84,51 @@
             },
             "required": [
                 "classname"
+            ],
+            "additionalProperties": false
+        },
+        "DataConverterConfig": {
+            "title": "DataConverterConfig",
+            "type": "object",
+            "properties": {
+                "classname": {
+                    "title": "Classname",
+                    "description": "The import path to the Python class that should be used, e.g., if your import statement looks like `from foo.bar import Baz`, then your classname would be `foo.bar.Baz`.",
+                    "type": "string"
+                },
+                "parameters": {
+                    "title": "Parameters",
+                    "description": "Optional dictionary that will be passed to the Python class specified by 'classname' when it is instantiated. If the object is a tsdat class, then the parameters will typically be made accessible under the `params` property on an instance of the class. See the documentation for individual classes for more information.",
+                    "default": {},
+                    "type": "object"
+                }
+            },
+            "required": [
+                "classname"
+            ]
+        },
+        "RetrievedVariableConfig": {
+            "title": "RetrievedVariableConfig",
+            "description": "Specifies how the variable should be retrieved from the raw dataset and the\npreprocessing steps (i.e. DataConverters) that should be applied.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "description": "The exact name of the variable in the raw dataset returned by the DataReader.",
+                    "type": "string"
+                },
+                "data_converters": {
+                    "title": "Data Converters",
+                    "description": "A list of DataConverters to run for this variable. Common choices include the tsdat UnitsConverter (classname: 'tsdat.io.converters.UnitsConverter') to convert the variable's data from its input units to specified output units, and the tsdat StringToDatetime converter (classname: 'tsdat.io.converters.StringToDatetime'), which takes dates/times formatted as strings and converts them into a datetime64 object that can be used throughout the rest of the pipeline. This property is optional and defaults to [].",
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DataConverterConfig"
+                    }
+                }
+            },
+            "required": [
+                "name"
             ],
             "additionalProperties": false
         }

--- a/.vscode/schema/retriever-schema.json
+++ b/.vscode/schema/retriever-schema.json
@@ -129,8 +129,7 @@
             },
             "required": [
                 "name"
-            ],
-            "additionalProperties": false
+            ]
         }
     }
 }

--- a/test/config/yaml/retriever.yaml
+++ b/test/config/yaml/retriever.yaml
@@ -5,7 +5,6 @@ readers:
   .*\.csv:
     classname: tsdat.io.readers.CSVReader
 
-# IDEA: Add the coords / data vars structure to the config object & generate schema
 coords:
   time:
     name: timestamp

--- a/test/config/yaml/retriever.yaml
+++ b/test/config/yaml/retriever.yaml
@@ -8,12 +8,11 @@ readers:
 # IDEA: Add the coords / data vars structure to the config object & generate schema
 coords:
   time:
-    .*:
-      name: timestamp
-      data_converters:
-        - classname: tsdat.io.converters.StringToDatetime
-          format: "%Y-%m-%d %H:%M:%S"
-          timezone: UTC
+    name: timestamp
+    data_converters:
+      - classname: tsdat.io.converters.StringToDatetime
+        format: "%Y-%m-%d %H:%M:%S"
+        timezone: UTC
 
 data_vars:
   first:

--- a/tsdat/config/retriever.py
+++ b/tsdat/config/retriever.py
@@ -1,24 +1,38 @@
-from typing import Dict, Pattern
-from pydantic import Extra
+import re
+from typing import Dict, List, Pattern, Union, cast
+from pydantic import BaseModel, Extra, Field, validator
 from .utils import ParameterizedConfigClass, YamlModel
 
 __all__ = ["RetrieverConfig"]
 
 
 class DataReaderConfig(ParameterizedConfigClass):
-    pass
-    # HACK: Can't do Pattern[str]: https://github.com/samuelcolvin/pydantic/issues/2636
-    # regex: Pattern = Field(  # type: ignore
-    #     "",
-    #     description="A regex pattern used to map input data keys (e.g., a file path or"
-    #     " url passed as input from the pipeline runner) to the DataReader that should"
-    #     " be used to read that resource. If there are multiple DataReader registered"
-    #     " and an input data key would be matched by the regex pattern of multiple"
-    #     " DataReaders, then only the DataReader corresponding with the first match will"
-    #     " be used. Because of this, we recommend ordering your DataReaders from most"
-    #     " specific pattern to least specific so that the most specific pattern will be"
-    #     " matched first.",
-    # )
+    ...
+
+
+class DataConverterConfig(ParameterizedConfigClass, extra=Extra.allow):
+    ...
+
+
+class RetrievedVariableConfig(BaseModel, extra=Extra.forbid):
+    """Specifies how the variable should be retrieved from the raw dataset and the
+    preprocessing steps (i.e. DataConverters) that should be applied."""
+
+    name: str = Field(
+        description="The exact name of the variable in the raw dataset returned by the"
+        " DataReader."
+    )
+    data_converters: List[DataConverterConfig] = Field(
+        [],
+        description="A list of DataConverters to run for this variable. Common choices"
+        " include the tsdat UnitsConverter (classname: "
+        "'tsdat.io.converters.UnitsConverter') to convert the variable's data from its"
+        " input units to specified output units, and the tsdat StringToDatetime"
+        " converter (classname: 'tsdat.io.converters.StringToDatetime'), which takes"
+        " dates/times formatted as strings and converts them into a datetime64 object"
+        " that can be used throughout the rest of the pipeline. This property is"
+        " optional and defaults to [].",
+    )
 
 
 class RetrieverConfig(ParameterizedConfigClass, YamlModel, extra=Extra.allow):
@@ -31,13 +45,38 @@ class RetrieverConfig(ParameterizedConfigClass, YamlModel, extra=Extra.allow):
     json schema for immediate validation. This class also provides a method to
     instantiate a tsdat.io.base.Retriever subclass from a parsed configuration file.
 
-    Args:
-        classname (str): The dotted module path to the pipeline that the specified
-        configurations should apply to. To use the built-in IngestPipeline, for example,
-        you would set 'tsdat.pipeline.pipelines.IngestPipeline' as the classname.
-        readers (Dict[str, DataReaderConfig]): The DataReaders to use for reading input
-        data.
-
     ---------------------------------------------------------------------------------"""
 
-    readers: Dict[Pattern, DataReaderConfig]  # type: ignore
+    # HACK: Can't do Pattern[str]: https://github.com/samuelcolvin/pydantic/issues/2636
+    readers: Dict[Pattern, DataReaderConfig] = Field(  # type: ignore
+        description="A dictionary mapping regex patterns to DataReaders that should be"
+        " used to read the input data. For each input given to the Retriever, the"
+        " mapping will be used to determine which DataReader to use. The patterns will"
+        " be searched in the order they are defined and the DataReader corresponding"
+        " with the first pattern that matches the input key will be used."
+    )
+    coords: Dict[str, Union[Dict[Pattern, RetrievedVariableConfig], RetrievedVariableConfig]] = Field(  # type: ignore
+        {},
+        description="A dictionary mapping output coordinate variable names to the"
+        " retrieval rules and preprocessing actions (i.e. DataConverters) that should"
+        " be applied to each retrieved coordinate variable.",
+    )
+    data_vars: Dict[str, Union[Dict[Pattern, RetrievedVariableConfig], RetrievedVariableConfig]] = Field(  # type: ignore
+        {},
+        description="A dictionary mapping output data_variable variable names to the"
+        " retrieval rules and preprocessing actions (i.e. DataConverters) that should"
+        " be applied to each retrieved coordinate variable.",
+    )
+
+    @validator("coords", "data_vars")
+    @classmethod
+    def coerce_to_patterned_retriever(cls, var_dict: Dict[str, Union[Dict[Pattern, RetrievedVariableConfig], RetrievedVariableConfig]]) -> Dict[str, Dict[Pattern[str], RetrievedVariableConfig]]:  # type: ignore
+        to_return: Dict[str, Dict[Pattern[str], RetrievedVariableConfig]] = {}  # type: ignore
+        for name, var_retriever in var_dict.items():  # type: ignore
+
+            if isinstance(var_retriever, RetrievedVariableConfig):
+                var_retriever = {re.compile(r".*"): var_retriever}
+            to_return[name] = cast(
+                Dict[Pattern[str], RetrievedVariableConfig], var_retriever
+            )
+        return to_return

--- a/tsdat/config/retriever.py
+++ b/tsdat/config/retriever.py
@@ -14,7 +14,7 @@ class DataConverterConfig(ParameterizedConfigClass, extra=Extra.allow):
     ...
 
 
-class RetrievedVariableConfig(BaseModel, extra=Extra.forbid):
+class RetrievedVariableConfig(BaseModel, extra=Extra.allow):
     """Specifies how the variable should be retrieved from the raw dataset and the
     preprocessing steps (i.e. DataConverters) that should be applied."""
 

--- a/tsdat/io/retrievers.py
+++ b/tsdat/io/retrievers.py
@@ -13,19 +13,19 @@ __all__ = ["DefaultRetriever"]
 logger = logging.getLogger(__name__)
 
 
-class VariableRetriever(BaseModel, extra=Extra.forbid):
+class RetrievedVariable(BaseModel, extra=Extra.forbid):
     name: str
     data_converters: List[DataConverter] = []
 
 
 class InputKeyRetrieverConfig:
     def __init__(self, input_key: str, retriever: "DefaultRetriever") -> None:
-        self.coords: Dict[str, VariableRetriever] = {}
-        self.data_vars: Dict[str, VariableRetriever] = {}
+        self.coords: Dict[str, RetrievedVariable] = {}
+        self.data_vars: Dict[str, RetrievedVariable] = {}
 
         def update_mapping(
-            to_update: Dict[str, VariableRetriever],
-            variable_dict: Dict[str, Dict[Pattern[str], VariableRetriever]],
+            to_update: Dict[str, RetrievedVariable],
+            variable_dict: Dict[str, Dict[Pattern[str], RetrievedVariable]],
         ):
             for name, retriever_dict in variable_dict.items():
                 for pattern, variable_retriever in retriever_dict.items():
@@ -71,12 +71,12 @@ class DefaultRetriever(Retriever):
     """A dictionary of DataReaders that should be used to read data provided an input
     key."""
 
-    coords: Dict[str, Dict[Pattern, VariableRetriever]]  # type: ignore
+    coords: Dict[str, Dict[Pattern, RetrievedVariable]]  # type: ignore
     """A dictionary mapping output coordinate names to the retrieval rules and
     preprocessing actions (e.g., DataConverters) that should be applied to each retrieved
     coordinate variable."""
 
-    data_vars: Dict[str, Dict[Pattern, VariableRetriever]]  # type: ignore
+    data_vars: Dict[str, Dict[Pattern, RetrievedVariable]]  # type: ignore
     """A dictionary mapping output data variable names to the retrieval rules and
     preprocessing actions (e.g., DataConverters) that should be applied to each
     retrieved data variable."""


### PR DESCRIPTION
Updated the `RetrieverConfig` to provide model information and schema validation for coords and data_vars. 

Also added a feature to drop the requirement that users specify a regex pattern for coordinate/data variable retrieval rules. To illustrate, in the screenshot below both the `time` coordinate and the `first` data_var will use the input variable name and data converters shown below for any input matching the regex pattern `.*`.

<img width="598" alt="image" src="https://user-images.githubusercontent.com/24307537/165862821-a392d8cc-6a32-46f7-823a-613399394c60.png">


Fixes https://github.com/tsdat/pipeline-template/issues/13 