### PR TITLE
Fix build warnings

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
 -r ../requirements.txt
-sphinx==3.5.4
-sphinx-rtd-theme==0.5.2
-sphinx-autoapi==1.8.1
-jinja2<3.1.0
-yamllint
+sphinx
+sphinx-rtd-theme
+sphinx-autoapi

--- a/docs/source/config/hook_functions.rst
+++ b/docs/source/config/hook_functions.rst
@@ -49,3 +49,4 @@ output. Below is shown a custom plotting example:
 
 .. autoclass:: tsdat.pipeline.pipelines.IngestPipeline
     :members: hook_customize_dataset, hook_finalize_dataset, hook_plot_dataset
+    :noindex:

--- a/docs/source/config/pydantic.rst
+++ b/docs/source/config/pydantic.rst
@@ -2,7 +2,7 @@
 
 Pydantic and Parameters
 =========================
-Tsdat makes use of the Pydantic libary (https://pydantic-docs.helpmanual.io/) to support automatic validation of
+Tsdat makes use of [Pydantic](https://pydantic-docs.helpmanual.io/) to support automatic validation of
 the yaml configuration files.  This means that each customizable class type in Tsdat that can be specified in a yaml
 file extends a Pydantic base model object.  To facilitate consistent format and validation checking of
 parameters, all Tsdat objects should include a ``Parameters`` inner class.  This means that if you create a custom

--- a/docs/source/config/quality_control.rst
+++ b/docs/source/config/quality_control.rst
@@ -14,7 +14,7 @@ data meets quality requirements:
     Each Quality Handler can be specified to run if a particular QC test
     fails. Quality handlers take the QC Checker's logical mask and use it to apply any QC or custom method to the data variable of question. For instance, it can be used to remove flagged data altogether or correct flagged values, such as interpolating to fill gaps in data.
 	
-Custom QC Checkers and QC Handlers are stored (typically) in ``pipelines/<ingest_name>/qc.py``.
+Custom QC Checkers and QC Handlers are stored (typically) in ``pipelines/<pipeline_module>/qc.py``.
 Once written, they must be specified in the ``config/quality.yaml`` file like shown:
 
 .. code-block:: yaml
@@ -29,10 +29,10 @@ Once written, they must be specified in the ``config/quality.yaml`` file like sh
 
       - name: The name of this quality check
         checker:
-          classname: pipelines.example_ingest.qc.CustomQualityChecker
+          classname: pipelines.example_pipeline.qc.CustomQualityChecker
           parameters: {}
         handlers:
-          - classname: pipelines.example_ingest.qc.CustomQualityHandler
+          - classname: pipelines.example_pipeline.qc.CustomQualityHandler
             parameters: {}
         apply_to: [COORDS, DATA_VARS]
 
@@ -41,8 +41,9 @@ Quality Checkers
 ----------------
 Quality Checkers are classes that are used to perform a QC test on a specific
 variable.  Each Quality Checker should extend the ``QualityChecker`` base
-class, and implement the abstract ``run`` method as shown below.  Each QualityChecker defined in the pipeline config file will
-be automatically initialized by the pipeline and invoked on the specified variables.
+class, and implement the abstract ``run`` method as shown below.  Each QualityChecker
+defined in the pipeline config file will be automatically initialized by the pipeline
+and invoked on the specified variables.
 
 .. code-block:: python
 
@@ -73,7 +74,7 @@ Tsdat built-in quality checkers:
 
 .. autosummary::
     :nosignatures:
-	
+
     ~tsdat.qc.checkers.QualityChecker
     ~tsdat.qc.checkers.CheckMissing
     ~tsdat.qc.checkers.CheckMonotonic
@@ -108,9 +109,9 @@ by the pipeline and invoked on the specified variables.
         Args:
             dataset (xr.Dataset): The dataset containing the variable to handle.
             variable_name (str): The name of the variable whose quality should be
-            handled.
+                handled.
             failures (NDArray[np.bool8]): The results of the QualityChecker for the
-            provided variable, where True values indicate a quality problem.
+                provided variable, where True values indicate a quality problem.
 
         Returns:
             xr.Dataset: The dataset after the QualityHandler has been run.
@@ -125,17 +126,18 @@ Tsdat built-in quality handlers:
 	
     ~tsdat.qc.handlers.QualityHandler
     ~tsdat.qc.handlers.RecordQualityResults
-    ~tsdat.qc.handlers.RemoveFailedValues
+    ~tsdat.qc.handlers.ReplaceFailedValues
     ~tsdat.qc.handlers.SortDatasetByCoordinate
-    ~tsdat.qc.handlers.SendEmailAWS
     ~tsdat.qc.handlers.FailPipeline
 
 .. automodule:: tsdat.qc.checkers
     :members:
     :undoc-members:
     :show-inheritance:
+    :noindex:
 	
 .. automodule:: tsdat.qc.handlers
     :members:
     :undoc-members:
     :show-inheritance:
+    :noindex:

--- a/tsdat/qc/checkers.py
+++ b/tsdat/qc/checkers.py
@@ -222,7 +222,7 @@ class CheckValidMin(_CheckMin):
 
 class CheckValidMax(_CheckMax):
     """------------------------------------------------------------------------------------
-    Checks for values greater than `valid_min'.
+    Checks for values greater than `valid_max'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -240,7 +240,7 @@ class CheckFailMin(_CheckMin):
 
 class CheckFailMax(_CheckMax):
     """------------------------------------------------------------------------------------
-    Checks for values greater than `fail_min'.
+    Checks for values greater than `fail_max'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -258,7 +258,7 @@ class CheckWarnMin(_CheckMin):
 
 class CheckWarnMax(_CheckMax):
     """------------------------------------------------------------------------------------
-    Checks for values greater than `warn_min'.
+    Checks for values greater than `warn_max'.
 
     ------------------------------------------------------------------------------------"""
 

--- a/tsdat/qc/checkers.py
+++ b/tsdat/qc/checkers.py
@@ -213,7 +213,7 @@ class _CheckMax(_ThresholdChecker):
 
 class CheckValidMin(_CheckMin):
     """------------------------------------------------------------------------------------
-    Checks for values less than `valid_min'.
+    Checks for values less than 'valid_min'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -222,7 +222,7 @@ class CheckValidMin(_CheckMin):
 
 class CheckValidMax(_CheckMax):
     """------------------------------------------------------------------------------------
-    Checks for values greater than `valid_max'.
+    Checks for values greater than 'valid_max'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -231,7 +231,7 @@ class CheckValidMax(_CheckMax):
 
 class CheckFailMin(_CheckMin):
     """------------------------------------------------------------------------------------
-    Checks for values less than `fail_min'.
+    Checks for values less than 'fail_min'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -240,7 +240,7 @@ class CheckFailMin(_CheckMin):
 
 class CheckFailMax(_CheckMax):
     """------------------------------------------------------------------------------------
-    Checks for values greater than `fail_max'.
+    Checks for values greater than 'fail_max'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -249,7 +249,7 @@ class CheckFailMax(_CheckMax):
 
 class CheckWarnMin(_CheckMin):
     """------------------------------------------------------------------------------------
-    Checks for values less than `warn_min'.
+    Checks for values less than 'warn_min'.
 
     ------------------------------------------------------------------------------------"""
 
@@ -258,7 +258,7 @@ class CheckWarnMin(_CheckMin):
 
 class CheckWarnMax(_CheckMax):
     """------------------------------------------------------------------------------------
-    Checks for values greater than `warn_max'.
+    Checks for values greater than 'warn_max'.
 
     ------------------------------------------------------------------------------------"""
 


### PR DESCRIPTION
Fixes #74 by adding `:noindex:` directives in appropriate places and by fixing a few typos in some docstrings. Also updated docs requirements.