### PR TITLE
Rename ReplaceFailedValues QualityHandler

### DIFF
--- a/docs/source/config/quality_control.rst
+++ b/docs/source/config/quality_control.rst
@@ -126,7 +126,7 @@ Tsdat built-in quality handlers:
 	
     ~tsdat.qc.handlers.QualityHandler
     ~tsdat.qc.handlers.RecordQualityResults
-    ~tsdat.qc.handlers.ReplaceFailedValues
+    ~tsdat.qc.handlers.RemoveFailedValues
     ~tsdat.qc.handlers.SortDatasetByCoordinate
     ~tsdat.qc.handlers.FailPipeline
 

--- a/docs/source/figures/pipeline.yaml
+++ b/docs/source/figures/pipeline.yaml
@@ -3,11 +3,11 @@ classname: tsdat.pipeline.ingest.IngestPipeline
 
 #  Regex patterns that should trigger this pipeline
 triggers:
-  - .*example_ingest.*\.csv
+  - .*example_pipeline.*\.csv
 
 # Retriever config
 retriever:
-  path: pipelines/example_ingest/config/retriever.yaml
+  path: pipelines/example_pipeline/config/retriever.yaml
 
 # Dataset config.  In this example, we use a dataset.yaml file that is shared across multiple pipelines,
 # but we override one global attribute specifying a different location and we add one additional variable attribute.

--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -204,7 +204,7 @@ def test_replace_failed_values(sample_dataset: xr.Dataset):
 
     failures: NDArray[np.bool8] = np.bool8([True, False, False, False])  # type: ignore
 
-    handler = ReplaceFailedValues()
+    handler = RemoveFailedValues()
     dataset = handler.run(sample_dataset, "monotonic_var", failures)
 
     assert_close(dataset, expected)

--- a/tsdat/qc/handlers.py
+++ b/tsdat/qc/handlers.py
@@ -10,7 +10,7 @@ __all__ = [
     "DataQualityError",
     "FailPipeline",
     "RecordQualityResults",
-    "ReplaceFailedValues",
+    "RemoveFailedValues",
     "SortDatasetByCoordinate",
 ]
 
@@ -109,7 +109,7 @@ class RecordQualityResults(QualityHandler):
         return dataset
 
 
-class ReplaceFailedValues(QualityHandler):
+class RemoveFailedValues(QualityHandler):
     """------------------------------------------------------------------------------------
     Replaces all failed values with the variable's _FillValue. If the variable does not
     have a _FillValue attribute then nan is used instead


### PR DESCRIPTION
Rename the `ReplaceFailedValues` `QualityHandler` to its original name: `RemoveFailedValues`.

When this PR is merged a new release of tsdat should be done with an updated version to indicate breaking changes have occurred.