### PR TITLE
Use instance variables for Storage and FileHandler

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,9 +33,12 @@ def dataset():
 
 @pytest.fixture(scope="session", autouse=True)
 def raw_dataset():
-    from tsdat.io.filehandlers import FileHandler
+    from tsdat.io.filehandlers import FileHandler, CsvHandler
 
-    return FileHandler.read(NON_MONOTONIC_CSV)
+    handler = FileHandler()
+    handler.register_file_handler("read", ".*", CsvHandler())
+
+    return handler.read(NON_MONOTONIC_CSV)
 
 
 def test_corrections_are_recorded(dataset):

--- a/tsdat/__init__.py
+++ b/tsdat/__init__.py
@@ -25,7 +25,6 @@ from tsdat.io import (
     FileHandler,
     CsvHandler,
     NetCdfHandler,
-    register_filehandler,
 )
 from tsdat.pipeline import Pipeline, IngestPipeline
 from tsdat.qc import (

--- a/tsdat/io/__init__.py
+++ b/tsdat/io/__init__.py
@@ -12,7 +12,6 @@ uses to manage I/O for the pipeline.  Specifically, it includes:
 from .filehandlers import (
     AbstractFileHandler,
     FileHandler,
-    register_filehandler,
     CsvHandler,
     NetCdfHandler,
     SplitNetCdfHandler,

--- a/tsdat/io/aws_storage.py
+++ b/tsdat/io/aws_storage.py
@@ -273,7 +273,7 @@ class AwsTemporaryStorage(TemporaryStorage):
             datastream_name,
             prev_date,
             next_date,
-            filetype=DatastreamStorage.default_file_type,
+            filetype=self.datastream_storage.default_file_type,
         )
 
         previous_filepath = None
@@ -411,7 +411,7 @@ class AwsStorage(DatastreamStorage):
                 storage_paths.append(file)
 
         if filetype is not None:
-            filter_func = DatastreamStorage.file_filters[filetype]
+            filter_func = self.file_filters[filetype]
             storage_paths = list(filter(filter_func, storage_paths))
 
         return sorted(storage_paths)

--- a/tsdat/io/filehandlers/__init__.py
+++ b/tsdat/io/filehandlers/__init__.py
@@ -2,7 +2,6 @@
 addition to methods for registering new File Handler objects."""
 from .file_handlers import AbstractFileHandler
 from .file_handlers import FileHandler
-from .file_handlers import register_filehandler
 
 # These imports register default file handlers
 from .csv_handler import CsvHandler

--- a/tsdat/io/filehandlers/file_handlers.py
+++ b/tsdat/io/filehandlers/file_handlers.py
@@ -1,8 +1,6 @@
 import warnings
-import functools
 import re
 import xarray as xr
-from deprecation import deprecated
 from typing import List, Dict, Literal, Union
 from tsdat.config import Config
 
@@ -158,55 +156,3 @@ class FileHandler:
 
         for pattern in patterns:
             handler_dict[pattern] = handler
-
-
-@deprecated(
-    deprecated_in="0.2.8",
-    removed_in="0.3.0",
-    details="This function will be removed in a future release. Use `FileHandler.register_file_handler()` instead.",
-)
-def register_filehandler(patterns: Union[str, List[str]]) -> AbstractFileHandler:
-    """Python decorator to register an AbstractFileHandler in the FileHandler
-    object. The FileHandler object will be used by tsdat pipelines to read and
-    write raw, intermediate, and processed data.
-
-    This decorator can be used to work with a specific AbstractFileHandler
-    without having to specify a config file. This is useful when using an
-    AbstractFileHandler for analysis or for tests outside of a pipeline. For
-    tsdat pipelines, handlers should always be specified via the storage
-    config file.
-
-    Example Usage:
-
-    .. code-block:: python
-
-        import xarray as xr
-        from tsdat.io import register_filehandler, AbstractFileHandler
-
-        @register_filehandler(["*.nc", "*.cdf"])
-        class NetCdfHandler(AbstractFileHandler):
-            def write(ds: xr.Dataset, filename: str, config: Config = None, **kwargs):
-                ds.to_netcdf(filename)
-            def read(filename: str, **kwargs) -> xr.Dataset:
-                xr.load_dataset(filename)
-    :param patterns:
-        The patterns (regex) that should be used to match a filepath to
-        the AbstractFileHandler provided.
-    :type patterns: Union[str, List[str]]
-    :return:
-        The original AbstractFileHandler class, after it has been registered
-        for use in tsdat pipelines.
-    :rtype: AbstractFileHandler
-    """
-
-    def decorator_register(cls):
-        FileHandler.register_file_handler("read", patterns, cls)
-        FileHandler.register_file_handler("write", patterns, cls)
-
-        @functools.wraps(cls)
-        def wrapper_register(*args, **kwargs):
-            return cls(*args, **kwargs)
-
-        return wrapper_register
-
-    return decorator_register

--- a/tsdat/io/filesystem_storage.py
+++ b/tsdat/io/filesystem_storage.py
@@ -105,7 +105,7 @@ class FilesystemTemporaryStorage(TemporaryStorage):
             datastream_name,
             prev_date,
             next_date,
-            filetype=DatastreamStorage.default_file_type,
+            filetype=self.datastream_storage.default_file_type,
         )
         dates = [DSUtil.get_date_from_filename(_file) for _file in files]
 
@@ -183,7 +183,7 @@ class FilesystemStorage(DatastreamStorage):
                     storage_paths.append(os.path.join(dir_to_check, file))
 
             if filetype is not None:
-                filter_func = DatastreamStorage.file_filters[filetype]
+                filter_func = self.file_filters[filetype]
                 storage_paths = list(filter(filter_func, storage_paths))
 
         return sorted(storage_paths)

--- a/tsdat/pipeline/ingest_pipeline.py
+++ b/tsdat/pipeline/ingest_pipeline.py
@@ -1,7 +1,6 @@
 import warnings
 import xarray as xr
 from typing import Dict, List, Union
-from tsdat.io.filehandlers import FileHandler
 from tsdat.qc import QualityManagement
 from tsdat.utils import DSUtil
 from .pipeline import Pipeline
@@ -160,7 +159,7 @@ class IngestPipeline(Pipeline):
 
             # read the raw file into a dataset
             with self.storage.tmp.fetch(file_path) as tmp_path:
-                dataset = FileHandler.read(tmp_path)
+                dataset = self.storage.handler_registry.read(tmp_path)
 
                 # Don't use dataset if no FileHandler is registered for it
                 if dataset is not None:

--- a/tsdat/pipeline/pipeline.py
+++ b/tsdat/pipeline/pipeline.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Union
 
 from tsdat.utils import DSUtil
 from tsdat.config import Config, DatasetDefinition, VariableDefinition
-from tsdat.io import DatastreamStorage, FileHandler
+from tsdat.io import DatastreamStorage
 
 
 class Pipeline(abc.ABC):
@@ -235,7 +235,9 @@ class Pipeline(abc.ABC):
             datastream_name, f"{start_date}.{start_time}"
         ) as netcdf_file:
             if netcdf_file:
-                prev_dataset = FileHandler.read(netcdf_file, config=self.config)
+                prev_dataset = self.storage.handler_registry.read(
+                    netcdf_file, config=self.config
+                )
 
         return prev_dataset
 
@@ -363,14 +365,14 @@ class Pipeline(abc.ABC):
 
     def decode_cf(self, dataset: xr.Dataset) -> xr.Dataset:
         """------------------------------------------------------------------------------------
-            Decodes the dataset according to CF conventions. This helps ensure that the dataset
-            is formatted correctly after it has been constructed from unstandardized sources or
-            heavily modified.
-            Args:
-                dataset (xr.Dataset): The dataset to decode.
-            Returns:
-                xr.Dataset: The decoded dataset.
-            ------------------------------------------------------------------------------------"""
+        Decodes the dataset according to CF conventions. This helps ensure that the dataset
+        is formatted correctly after it has been constructed from unstandardized sources or
+        heavily modified.
+        Args:
+            dataset (xr.Dataset): The dataset to decode.
+        Returns:
+            xr.Dataset: The decoded dataset.
+        ------------------------------------------------------------------------------------"""
         # We have to make sure that time variables do not have units set as attrs, and
         # instead have units set on the encoding or else xarray will crash when trying
         # to save: https://github.com/pydata/xarray/issues/3739


### PR DESCRIPTION
This PR changes how the `DatastreamStorage` and `FileHandler` classes operate so that the data they contain is stored in *instances* of the class instead of as a class variable.

This fixes several headaches caused by tests failing in GitHub Actions but passing locally for the ingest-awaken repository, among others, due to how tests were being run. Now, regex patterns configured in the storage config file for internal file handlers will not clobber the file handlers registered for other ingests.