### PR TITLE
Improve retrieval and transformation methods

### DIFF
--- a/test/io/yaml/vap-retriever-2D.yaml
+++ b/test/io/yaml/vap-retriever-2D.yaml
@@ -1,4 +1,6 @@
 classname: tsdat.StorageRetriever
+# parameters:
+#   datastreams:
 
 coords:
   time:
@@ -22,6 +24,31 @@ data_vars:
         - classname: tsdat.UnitsConverter
           input_units: degF
 
+  # retriever.get_inputs --> Dict[InputKey: xr.Dataset]
+  # retriever.retrieve_variables --> Dict[VarName: Tuple[RetrievalRule, List[xr.DataArray]]
+  # --> post_retrieval_hook
+  # retriever.merge_variable_arrays  --> Dict[VarName: Tuple[RetrievalRule, xr.DataArray]]
+  # --> pre convert hook ?
+  # retrieved_data = retriever.convert_data --> Dict[VarName: xr.DataArray]
+  # --> post convert hook ?
+  # output_dataset = create_output_dataset(retrieved_data) --> xr.Dataset
+  # --> customize dataset hook
+  # apply qc
+  # --> post qc hook    <--------------- change finalize to hook_post_qc
+  # save
+  # --> plot dataset hook
+
+  # ${RUN_LOCATION} should be a substitution allowed in the regex patterns
+
+  # Of note: VAPs should always use the highest available priority input for each data variable
+  # because we are assuming that each pattern refers to a different datastream and data from different
+  # datastreams should not be combined into the same variable (at least not automatically)
+
+  # For ingests we assume that the patterns match different *files* and that matched files for the same
+  # pattern are obtained from the same instrument/source and may be merged safely.
+
+  # Per variable: retrieval rules: List[retrieval rule] which is the "- pattern: .*xyz.* \n..."" stuff
+
   humidity:
     # Note: buoy_z06 already has the correct shape for humidity (time)
     .*buoy_z06.*:
@@ -32,6 +59,12 @@ data_vars:
       name: rh
       data_converters:
         - classname: tsdat.NearestNeighbor
+
+    # # TODO: Make this a list instead of a dict: more flexible for different types of selections.
+    # - pattern: .*buoy_z07.*
+    #   name: rh
+    #   data_converters:
+    #     - classname: tsdat.NearestNeighbor
 
   pressure:
     # Note: buoy_z07 doesn't have "pres" data, should warn and move to buoy_z06

--- a/tsdat/config/retriever.py
+++ b/tsdat/config/retriever.py
@@ -14,7 +14,7 @@ class DataConverterConfig(ParameterizedConfigClass, extra=Extra.allow):
     ...
 
 
-class RetrievedVariableConfig(BaseModel, extra=Extra.allow):
+class RetrievedVariableRuleConfig(BaseModel, extra=Extra.allow):
     """Specifies how the variable should be retrieved from the raw dataset and the
     preprocessing steps (i.e. DataConverters) that should be applied."""
 
@@ -64,13 +64,13 @@ class RetrieverConfig(ParameterizedConfigClass, YamlModel, extra=Extra.allow):
         " be searched in the order they are defined and the DataReader corresponding"
         " with the first pattern that matches the input key will be used."
     )
-    coords: Dict[str, Union[Dict[Pattern, RetrievedVariableConfig], RetrievedVariableConfig]] = Field(  # type: ignore
+    coords: Dict[str, Union[Dict[Pattern, RetrievedVariableRuleConfig], RetrievedVariableRuleConfig]] = Field(  # type: ignore
         {},
         description="A dictionary mapping output coordinate variable names to the"
         " retrieval rules and preprocessing actions (i.e. DataConverters) that should"
         " be applied to each retrieved coordinate variable.",
     )
-    data_vars: Dict[str, Union[Dict[Pattern, RetrievedVariableConfig], RetrievedVariableConfig]] = Field(  # type: ignore
+    data_vars: Dict[str, Union[Dict[Pattern, RetrievedVariableRuleConfig], RetrievedVariableRuleConfig]] = Field(  # type: ignore
         {},
         description="A dictionary mapping output data_variable variable names to the"
         " retrieval rules and preprocessing actions (i.e. DataConverters) that should"
@@ -79,13 +79,13 @@ class RetrieverConfig(ParameterizedConfigClass, YamlModel, extra=Extra.allow):
 
     @validator("coords", "data_vars")
     @classmethod
-    def coerce_to_patterned_retriever(cls, var_dict: Dict[str, Union[Dict[Pattern, RetrievedVariableConfig], RetrievedVariableConfig]]) -> Dict[str, Dict[Pattern[str], RetrievedVariableConfig]]:  # type: ignore
-        to_return: Dict[str, Dict[Pattern[str], RetrievedVariableConfig]] = {}  # type: ignore
+    def coerce_to_patterned_retriever(cls, var_dict: Dict[str, Union[Dict[Pattern, RetrievedVariableRuleConfig], RetrievedVariableRuleConfig]]) -> Dict[str, Dict[Pattern[str], RetrievedVariableRuleConfig]]:  # type: ignore
+        to_return: Dict[str, Dict[Pattern[str], RetrievedVariableRuleConfig]] = {}  # type: ignore
         for name, var_retriever in var_dict.items():  # type: ignore
 
-            if isinstance(var_retriever, RetrievedVariableConfig):
+            if isinstance(var_retriever, RetrievedVariableRuleConfig):
                 var_retriever = {re.compile(r".*"): var_retriever}
             to_return[name] = cast(
-                Dict[Pattern[str], RetrievedVariableConfig], var_retriever
+                Dict[Pattern[str], RetrievedVariableRuleConfig], var_retriever
             )
         return to_return

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -28,7 +28,7 @@ __all__ = [
     "FileHandler",
     "Retriever",
     "Storage",
-    "RetrievalRuleSelections",
+    "SelectedRetrievalRules",
     "RetrievedDataset",
 ]
 
@@ -36,6 +36,11 @@ __all__ = [
 # Verbose type aliases
 InputKey = str
 VarName = str
+
+
+# class XXX(NamedTuple):
+#     coords: Dict[VarName, Dict[InputKey, xr.DataArray]]
+#     data_vars: Dict[VarName, Dict[InputKey, xr.DataArray]]
 
 
 class RetrievedDataset(NamedTuple):
@@ -234,19 +239,22 @@ class FileHandler(DataHandler):
     writer: FileWriter
 
 
-# TODO: This needs a better name
-class RetrievedVariable(BaseModel, extra=Extra.forbid):
+class VariableRetrievalRule(BaseModel, extra=Extra.forbid):
     """Tracks the name of the input variable and the converters to apply."""
+
+    # TODO Document this
 
     name: str
     data_converters: List[DataConverter] = []
 
 
-class RetrievalRuleSelections(NamedTuple):
+class SelectedRetrievalRules(NamedTuple):
     """Maps variable names to the rules and conversions that should be applied."""
 
-    coords: Dict[VarName, RetrievedVariable]
-    data_vars: Dict[VarName, RetrievedVariable]
+    # TODO Document this
+
+    coords: Dict[VarName, VariableRetrievalRule]
+    data_vars: Dict[VarName, VariableRetrievalRule]
 
 
 class Retriever(ParameterizedClass, ABC):
@@ -263,12 +271,12 @@ class Retriever(ParameterizedClass, ABC):
     readers: Optional[Dict[Pattern, Any]]  # type: ignore
     """Mapping of readers that should be used to read data given input keys."""
 
-    coords: Dict[str, Dict[Pattern, RetrievedVariable]]  # type: ignore
+    coords: Dict[str, Dict[Pattern, VariableRetrievalRule]]  # type: ignore
     """A dictionary mapping output coordinate names to the retrieval rules and
     preprocessing actions (e.g., DataConverters) that should be applied to each retrieved
     coordinate variable."""
 
-    data_vars: Dict[str, Dict[Pattern, RetrievedVariable]]  # type: ignore
+    data_vars: Dict[str, Dict[Pattern, VariableRetrievalRule]]  # type: ignore
     """A dictionary mapping output data variable names to the retrieval rules and
     preprocessing actions (e.g., DataConverters) that should be applied to each
     retrieved data variable."""


### PR DESCRIPTION
This PR is targeted at improving support for retrieval and transformation methods. Retrieval mechanisms and schema are being reworked for better flexibility, ease of use, and maintainability.

Tasks:
- [ ] Update retriever schema to use lists of variable retrieval rules instead of a dictionary where regex patterns map to the input name and converters
- [ ] Make retriever logic more robust and similar between ingests and transformation pipelines.
- [ ] Begin implementing support for QC metrics in data converters that should transform data arrays (e.g., NearestNeighbor)
- [ ] Update documentation