### PR TITLE
Add coords to dataset before data vars

### DIFF
--- a/tsdat/pipeline/base.py
+++ b/tsdat/pipeline/base.py
@@ -67,12 +67,12 @@ class Pipeline(ParameterizedClass, ABC):
             DatasetConfig.
 
         -----------------------------------------------------------------------------"""
-        output_vars = set(self.dataset_config.coords) | set(
+        output_vars = list(self.dataset_config.coords) + list(
             self.dataset_config.data_vars
         )
-        retrieved_vars = cast("set[str]", set(dataset.variables))
-        vars_to_drop = retrieved_vars - output_vars
-        vars_to_add = output_vars - retrieved_vars
+        retrieved_variables = cast(List[str], list(dataset.variables))
+        vars_to_drop = [ret for ret in retrieved_variables if ret not in output_vars]
+        vars_to_add = [out for out in output_vars if out not in retrieved_variables]
 
         dataset = dataset.drop_vars(vars_to_drop)
         dataset = self._add_dataset_variables(dataset, vars_to_add)


### PR DESCRIPTION
This PR fixes a bug where new variables were sometimes added to the dataset before new coordinate variables, causing the program to crash due to the unknown size/values of a coordinate dimension.

Using a list of coordinate, then variable names instead of a combined `set` of names preserves the addition order and resolves this issue.