### PR TITLE
Create options for storage path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = Path("README.md").read_text()
 requirements = Path("requirements.txt").read_text().strip().splitlines()
 REQUIREMENTS = [req for req in requirements if not req.startswith("#")]
 
-VERSION = os.environ["TSDAT_VERSION"]
+VERSION = os.getenv("TSDAT_VERSION")
 
 
 setuptools.setup(


### PR DESCRIPTION
Concurrent development with pipelines that use S3 storage. Added the ability to customize the storage path with some limitations. Since the goal is to use the local template to build pipelines using AWS lambda, I'm attempting to keep the storage parameters similar between `FileSystem` and `FileSystemS3`.
One of the priorities with setting up tsdat as a real-time data pipeline is storing data by year/month/day. I added a workaround to be able to store data and ancillary files under this concept, though the changes will break the current development around file searching, namely `fetch_data`.