### PR TITLE
Expand CSV writer to save metadata and 2D variables

### DIFF
--- a/test/io/test_data_handlers.py
+++ b/test/io/test_data_handlers.py
@@ -163,7 +163,7 @@ def test_csv_writer(sample_dataset: xr.Dataset, sample_dataframe: pd.DataFrame):
 
     tmp_file = Path(tmp_dir.name) / "test_writer.csv"
     writer.write(sample_dataset, tmp_file)
-    df: pd.DataFrame = pd.read_csv(tmp_file.with_name("test_writer.1D.csv"))  # type: ignore
+    df: pd.DataFrame = pd.read_csv(tmp_file)  # type: ignore
     assert_frame_equal(df, expected)
 
     tmp_dir.cleanup()
@@ -199,7 +199,7 @@ def test_zarr_writer(sample_dataset: xr.Dataset):
     "handler_class, output_key",
     [
         (NetCDFHandler, "test_dataset.nc"),
-        (CSVHandler, "test_dataframe.csv"),
+        (CSVHandler, "test_dataframe.1D.csv"),
         (ParquetHandler, "test_dataframe.parquet"),
         (ZarrHandler, "test_dataset.zarr"),
     ],

--- a/test/io/test_data_handlers.py
+++ b/test/io/test_data_handlers.py
@@ -163,7 +163,7 @@ def test_csv_writer(sample_dataset: xr.Dataset, sample_dataframe: pd.DataFrame):
 
     tmp_file = Path(tmp_dir.name) / "test_writer.csv"
     writer.write(sample_dataset, tmp_file)
-    df: pd.DataFrame = pd.read_csv(tmp_file)  # type: ignore
+    df: pd.DataFrame = pd.read_csv(tmp_file.with_name("test_writer.1D.csv"))  # type: ignore
     assert_frame_equal(df, expected)
 
     tmp_dir.cleanup()

--- a/tsdat/io/writers.py
+++ b/tsdat/io/writers.py
@@ -168,9 +168,8 @@ class CSVWriter(FileWriter):
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any
     ) -> None:
-        # QUESTION: Can we reliably write the dataset metadata to a separate file such
-        # that it can always be retrieved? If not, should we declare this as a format
-        # incapable of "round-tripping" (i.e., ds != read(write(ds)) for csv format)?
+        # QUESTION: Is this format capable of "round-tripping"?
+        # (i.e., ds != read(write(ds)) for csv format)
         d1: List[Hashable] = []
         d2: List[Hashable] = []
         for var in dataset:
@@ -187,14 +186,14 @@ class CSVWriter(FileWriter):
         name = filepath.stem  # type: ignore
 
         # Save header data
-        header_filepath = filepath.with_stem(name + ".hdr")  # type: ignore
+        header_filepath = filepath.with_suffix(".hdr.csv")  # type: ignore
         header = dataset.attrs
         with open(str(header_filepath), "w", newline="\n") as fp:
             for key in header:
                 fp.write(f"{key},{header[key]}\n")
 
         # Save variable metadata
-        metadata_filepath = filepath.with_stem(name + ".attrs")  # type: ignore
+        metadata_filepath = filepath.with_suffix(".attrs.csv")  # type: ignore
         var_metadata: List[Dict[str, Any]] = []
         for var in dataset:
             attrs = dataset[var].attrs
@@ -215,7 +214,7 @@ class CSVWriter(FileWriter):
 
         if d2:
             # Save 2D variables
-            dim2_filepath = filepath.with_stem(name + ".2D")  # type: ignore
+            dim2_filepath = filepath.with_suffix(".2D.csv")  # type: ignore
             ds_2d = dataset.drop_vars(d1)  # drop 1D variables
             df_2d = ds_2d.to_dataframe(self.parameters.dim_order)  # type: ignore
             df_2d.to_csv(dim2_filepath, **self.parameters.to_csv_kwargs)  # type: ignore

--- a/tsdat/io/writers.py
+++ b/tsdat/io/writers.py
@@ -142,7 +142,7 @@ class SplitNetCDFWriter(NetCDFWriter):
             ds_temp = dataset.sel(time=slice(t1, t2))
 
             new_filename = get_filename(ds_temp, self.file_extension)
-            new_filepath = filepath.with_name(new_filename) # type: ignore
+            new_filepath = filepath.with_name(new_filename)  # type: ignore
 
             ds_temp.to_netcdf(new_filepath, **to_netcdf_kwargs)  # type: ignore
 
@@ -206,13 +206,12 @@ class CSVWriter(FileWriter):
 
         if d1:
             # Save 1D variables
-            dim1_filepath = filepath.with_stem(name + ".1D")  # type: ignore
             d2.extend(
                 [v for v in dataset.coords if v != "time"]
             )  # add 2D coordinates to remove list
             ds_1d = dataset.drop_vars(d2)  # drop 2D variables
             df_1d = ds_1d.to_dataframe()
-            df_1d.to_csv(dim1_filepath, **self.parameters.to_csv_kwargs)  # type: ignore
+            df_1d.to_csv(filepath, **self.parameters.to_csv_kwargs)  # type: ignore
 
         if d2:
             # Save 2D variables


### PR DESCRIPTION
Replaces the current csv writer, which saves 1D variables but no metadata. This reader divides an xarray dataset into 2 files: a header file containing global attributes, a attributes file that contains variable metadata, a file containing 1D variables, and a file containing 2D variables. 2D variables are flattened into a coordinate list (x, y, var1, var2, ... varN) before saving.