### PR TITLE
Set retriever to assign variable datatypes

### DIFF
--- a/tsdat/pipeline/base.py
+++ b/tsdat/pipeline/base.py
@@ -75,6 +75,7 @@ class Pipeline(ParameterizedClass, ABC):
         vars_to_add = [out for out in output_vars if out not in retrieved_variables]
 
         dataset = dataset.drop_vars(vars_to_drop)
+        dataset = self._add_dataset_dtypes(dataset)
         dataset = self._add_dataset_variables(dataset, vars_to_add)
         dataset = self._add_dataset_attrs(dataset, output_vars)
         # TODO: reorder dataset coords / data vars to match the order in the config file
@@ -97,6 +98,12 @@ class Pipeline(ParameterizedClass, ABC):
                 data = np.array(data, dtype=dtype)  # type: ignore
 
             dataset[name] = xr.DataArray(data=data, dims=dims)
+        return dataset
+
+    def _add_dataset_dtypes(self, dataset: xr.Dataset) -> xr.Dataset:
+        for name in dataset.data_vars:
+            dtype = self.dataset_config[name].dtype  # type: ignore
+            dataset[name] = dataset[name].astype(dtype)
         return dataset
 
     def _add_dataset_attrs(


### PR DESCRIPTION
Bugfix for datatypes of variables listed in retriever and dataset config files are passed over in the retrieve config. Fixes #93 