### PR TITLE
Record SortDatasetByCoordinate corrections

### DIFF
--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -219,7 +219,8 @@ def test_sortdataset_by_coordinate(sample_dataset: xr.Dataset):
 
     failures: NDArray[np.bool8] = np.bool8([True, True, True, True])  # type: ignore
 
-    handler = SortDatasetByCoordinate()
+    handler = SortDatasetByCoordinate(parameters=dict(correction="Sorted time data!"))  # type: ignore
     dataset = handler.run(input_dataset, "time", failures)
 
     assert_close(dataset, expected)
+    assert dataset.time.attrs.get("corrections_applied") == ["Sorted time data!"]

--- a/tsdat/qc/handlers.py
+++ b/tsdat/qc/handlers.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Extra, Field
 from typing import Literal
 from numpy.typing import NDArray
 from .base import QualityHandler
+from ..utils import record_corrections_applied
 
 
 __all__ = [
@@ -13,20 +14,6 @@ __all__ = [
     "RemoveFailedValues",
     "SortDatasetByCoordinate",
 ]
-
-# def record_correction(self, variable_name: str):
-#     """If a correction was made to variable data to fix invalid values
-#     as detected by a quality check, this method will record the fix
-#     to the appropriate variable attribute.  The correction description
-#     will come from the handler params which get set in the pipeline config
-#     file.
-
-#     :param variable_name: Name
-#     :type variable_name: str
-#     """
-#     correction = self.params.get("correction", None)
-#     if correction:
-#         utils.record_corrections_applied(self.ds, variable_name, correction)
 
 
 class DataQualityError(ValueError):
@@ -135,6 +122,8 @@ class SortDatasetByCoordinate(QualityHandler):
         ascending: bool = True
         """Whether to sort the dataset in ascending order. Defaults to True."""
 
+        correction: str = "Coordinate data was sorted in order to ensure monotonicity."
+
     parameters: Parameters = Parameters()
 
     def run(
@@ -142,4 +131,7 @@ class SortDatasetByCoordinate(QualityHandler):
     ) -> xr.Dataset:
         if failures.any():
             dataset = dataset.sortby(variable_name, ascending=self.parameters.ascending)  # type: ignore
+            record_corrections_applied(
+                dataset, variable_name, self.parameters.correction
+            )
         return dataset


### PR DESCRIPTION
This PR adds support for passing a 'correction' config parameter to the `SortDatasetByCoordinate` quality handler, which is the previous behavior of tsdat 