### PR TITLE
Fix quality check bugs, other qc improvements

### DIFF
--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -3,6 +3,7 @@ import xarray as xr
 import pandas as pd
 import numpy as np
 from numpy.typing import NDArray
+import pytest
 from pytest import fixture
 from tsdat.qc.checkers import *
 from tsdat.qc.handlers import *

--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -158,6 +158,21 @@ def test_check_max_classes(sample_dataset: xr.Dataset):
     assert np.array_equal(results, expected)  # type: ignore
 
 
+def test_valid_delta():
+    ds = xr.Dataset(
+        coords={
+            "time": pd.date_range("2022-03-24 21:43:00", "2022-03-24 21:45:00", periods=3),  # type: ignore
+            "height": np.array([1, 2]),
+        },
+        data_vars={
+            "wind_speed": (["time", "height"], np.array([[10, 20], [11, 25], [16, 31]]), {"units": "m/s", "valid_delta": 5})  # type: ignore
+        },
+    )
+    expected = np.array([[False, False], [False, False], [False, True]])
+    results = CheckValidDelta().run(ds, "wind_speed")
+    assert np.array_equal(results, expected)  # type: ignore
+
+
 def test_check_delta_classes(sample_dataset: xr.Dataset):
     var_name = "monotonic_var"
     expected = np.bool8([False, False, False, True])

--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -173,6 +173,21 @@ def test_valid_delta():
     assert np.array_equal(results, expected)  # type: ignore
 
 
+def test_monotonic_check_ignores_string_vars(capsys: pytest.CaptureFixture[str]):
+    ds = xr.Dataset(
+        coords={
+            "time": pd.date_range("2022-03-24 21:43:00", "2022-03-24 21:45:00", periods=3),  # type: ignore
+            "dir": ["N", "E", "S", "W"],
+        },
+        data_vars={
+            "wind_speed": (["time", "dir"], np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]))  # type: ignore
+        },
+    )
+    expected = np.array([False, False, False, False])
+    results = CheckMonotonic().run(ds, "dir")  # type: ignore
+    assert np.array_equal(results, expected)  # type: ignore
+
+
 def test_check_delta_classes(sample_dataset: xr.Dataset):
     var_name = "monotonic_var"
     expected = np.bool8([False, False, False, True])

--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 from numpy.typing import NDArray
 from pytest import fixture
@@ -263,3 +264,31 @@ def test_sortdataset_by_coordinate(sample_dataset: xr.Dataset):
 
     assert_close(dataset, expected)
     assert dataset.time.attrs.get("corrections_applied") == ["Sorted time data!"]
+
+
+def test_fail_pipeline_provides_useful_message(caplog: Any):
+
+    ds = xr.Dataset(
+        coords={
+            "time": pd.date_range("2022-03-24 21:43:00", "2022-03-24 21:45:00", periods=3),  # type: ignore
+            "dir": ["X", "Y", "Z"],
+        },
+        data_vars={
+            "position": (["time", "dir"], np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))  # type: ignore
+        },
+    )
+
+    failures = np.array(
+        [[False, False, False], [False, False, False], [False, True, False]]
+    )
+    with pytest.raises(
+        DataQualityError, match=r".*Quality results for variable 'position'.*"
+    ) as err:
+        _ = FailPipeline().run(ds, "position", failures)
+
+    msg = err.value.args[0]
+
+    assert "Quality results for variable 'position' indicate a fatal error" in msg
+    assert "1 / 9 values failed" in msg
+    assert "The first failures occur at indexes: [[2, 1]]" in msg
+    assert "The corresponding values are: [8]" in msg

--- a/tsdat/qc/checkers.py
+++ b/tsdat/qc/checkers.py
@@ -350,7 +350,8 @@ class _CheckDelta(_ThresholdChecker):
         data: NDArray[Any] = var_data.data
         axis = var_data.get_axis_num(self.parameters.dim)
 
-        diff: NDArray[Any] = np.absolute(np.diff(data, axis=axis, prepend=data[0]))  # type: ignore
+        prepend = np.expand_dims(np.take(data, 0, axis=axis), axis=axis)  # type: ignore
+        diff: NDArray[Any] = np.absolute(np.diff(data, axis=axis, prepend=prepend))  # type: ignore
         failures = diff > threshold if self.allow_equal else diff >= threshold
 
         return failures


### PR DESCRIPTION
Closes #50 by adding useful debugging information to the `FailPipeline` QC handler error message.
Fixes #98 by passing the check with a warning for string data types.
Fixes #125 by using better dimension-agnostic logic for preserving shape after `np.diff`