### PR TITLE
Add docs for config overrides

### DIFF
--- a/.vscode/schema/pipeline-schema.json
+++ b/.vscode/schema/pipeline-schema.json
@@ -87,12 +87,13 @@
             "properties": {
                 "path": {
                     "title": "Path",
+                    "description": "Path to the configuration file to borrow configurations from.\nNote that this path is relative to the project root, so you should include any paths in between the project root and your config file.\nE.g., `pipelines/lidar/config/dataset.yaml`",
                     "format": "file-path",
                     "type": "string"
                 },
                 "overrides": {
                     "title": "Overrides",
-                    "default": {},
+                    "description": "Overrides to apply to the config file referenced by `path`.\nOverrides are defined in `key`: `value` pairs, where the `key` is a pointer to the object in the config file to override and the `value` is what should replace it.\nThe format of the keys is a cross between path-like structures and a python dictionary. For example, to change the 'location_id' property on the python object `obj = {'attrs': {'location_id': 'abc'}, 'data_vars': {...}}` to 'sgp' you would write `/attrs/location_id: 'sgp'`.\nOverrides are implemented using https://python-json-pointer.readthedocs.io/en/latest/tutorial.html",
                     "type": "object"
                 }
             },
@@ -239,12 +240,13 @@
             "properties": {
                 "path": {
                     "title": "Path",
+                    "description": "Path to the configuration file to borrow configurations from.\nNote that this path is relative to the project root, so you should include any paths in between the project root and your config file.\nE.g., `pipelines/lidar/config/dataset.yaml`",
                     "format": "file-path",
                     "type": "string"
                 },
                 "overrides": {
                     "title": "Overrides",
-                    "default": {},
+                    "description": "Overrides to apply to the config file referenced by `path`.\nOverrides are defined in `key`: `value` pairs, where the `key` is a pointer to the object in the config file to override and the `value` is what should replace it.\nThe format of the keys is a cross between path-like structures and a python dictionary. For example, to change the 'location_id' property on the python object `obj = {'attrs': {'location_id': 'abc'}, 'data_vars': {...}}` to 'sgp' you would write `/attrs/location_id: 'sgp'`.\nOverrides are implemented using https://python-json-pointer.readthedocs.io/en/latest/tutorial.html",
                     "type": "object"
                 }
             },
@@ -570,12 +572,13 @@
             "properties": {
                 "path": {
                     "title": "Path",
+                    "description": "Path to the configuration file to borrow configurations from.\nNote that this path is relative to the project root, so you should include any paths in between the project root and your config file.\nE.g., `pipelines/lidar/config/dataset.yaml`",
                     "format": "file-path",
                     "type": "string"
                 },
                 "overrides": {
                     "title": "Overrides",
-                    "default": {},
+                    "description": "Overrides to apply to the config file referenced by `path`.\nOverrides are defined in `key`: `value` pairs, where the `key` is a pointer to the object in the config file to override and the `value` is what should replace it.\nThe format of the keys is a cross between path-like structures and a python dictionary. For example, to change the 'location_id' property on the python object `obj = {'attrs': {'location_id': 'abc'}, 'data_vars': {...}}` to 'sgp' you would write `/attrs/location_id: 'sgp'`.\nOverrides are implemented using https://python-json-pointer.readthedocs.io/en/latest/tutorial.html",
                     "type": "object"
                 }
             },
@@ -704,12 +707,13 @@
             "properties": {
                 "path": {
                     "title": "Path",
+                    "description": "Path to the configuration file to borrow configurations from.\nNote that this path is relative to the project root, so you should include any paths in between the project root and your config file.\nE.g., `pipelines/lidar/config/dataset.yaml`",
                     "format": "file-path",
                     "type": "string"
                 },
                 "overrides": {
                     "title": "Overrides",
-                    "default": {},
+                    "description": "Overrides to apply to the config file referenced by `path`.\nOverrides are defined in `key`: `value` pairs, where the `key` is a pointer to the object in the config file to override and the `value` is what should replace it.\nThe format of the keys is a cross between path-like structures and a python dictionary. For example, to change the 'location_id' property on the python object `obj = {'attrs': {'location_id': 'abc'}, 'data_vars': {...}}` to 'sgp' you would write `/attrs/location_id: 'sgp'`.\nOverrides are implemented using https://python-json-pointer.readthedocs.io/en/latest/tutorial.html",
                     "type": "object"
                 }
             },

--- a/docs/source/config/pipeline_config.rst
+++ b/docs/source/config/pipeline_config.rst
@@ -24,8 +24,92 @@ An annotated example of an ingest pipeline config file is provided below:
     :language: yaml
 
 
+Overrides
+---------
+
 You may have noticed the **overrides** option used in the dataset configuration. This option can be used to
 override or add values in the source configuration file. Here we are changing the *location_id* global
 attribute to "sgp" and adding a new attribute to the data variable named "first". Overrides enhance the
 reusability of configuration files, allowing you to define a base configuration file and override specific
 features of it as needed for instruments at different sites.
+
+Consider the example `pipelines/lidar/config/dataset.yaml` file below:
+
+.. code-block:: yaml
+
+    attrs:
+      title: My Dataset
+      location_id: sgp
+      dataset_name: lidar
+      data_level: b1
+    coords:
+      time:
+        dims: [time]
+        dtype: datetime64[s]
+        attrs:
+          units: Seconds since 1970-01-01 00:00:00
+    data_vars:
+      wind_speed:
+        dims: [time]
+        dtype: float
+        attrs:
+          units: m/s
+          valid_range: [0, 30]
+      
+
+
+The `pipeline.yaml` file can define overrides as follows:
+
+.. code-block:: yaml
+
+    dataset:
+      path: pipelines/lidar/config/dataset.yaml
+      overrides:
+
+        # Changing existing properties via dictionary access
+        /attrs/location_id: hou
+        
+        # Adding properties / attributes via dictionary access
+        /data_vars/wind_speed/attrs/comment: This adds a 'comment' attribute!
+        
+        # Adding new variables
+        /data_vars/wind_dir:
+          dims: [time]
+          dtype: float
+          attrs:
+            units: deg
+            comment: This is a brand new variable called 'wind_dir'
+
+        # Changing properties by array index
+        /data_variables/wind_speed/attrs/valid_range/1: 50
+
+
+This is equivalent to defining a new `dataset.yaml` file as follows:
+
+.. code-block:: yaml
+
+    attrs:
+      title: My Dataset
+      location_id: hou
+      dataset_name: lidar
+      data_level: b1
+    coords:
+      time:
+        dims: [time]
+        dtype: datetime64[s]
+        attrs:
+          units: Seconds since 1970-01-01 00:00:00
+    data_vars:
+      wind_speed:
+        dims: [time]
+        dtype: float
+        attrs:
+          units: m/s
+          valid_range: [0, 50]
+          comment: This adds a 'comment' attribute!
+      wind_dir:
+        dims: [time]
+        dtype: float
+        attrs:
+          units: deg
+          comment: This is a brand new variable called 'wind_dir'

--- a/tsdat/config/utils.py
+++ b/tsdat/config/utils.py
@@ -23,6 +23,7 @@ from typing import (
 
 __all__ = [
     "ParameterizedConfigClass",
+    "Overrideable",
     "recursive_instantiate",
     "read_yaml",
     "get_code_version",
@@ -67,8 +68,25 @@ Config = TypeVar("Config", bound=BaseModel)
 
 
 class Overrideable(YamlModel, GenericModel, Generic[Config], extra=Extra.forbid):
-    path: FilePath
-    overrides: Dict[str, Any] = {}
+    path: FilePath = Field(
+        description="Path to the configuration file to borrow configurations from.\n"
+        "Note that this path is relative to the project root, so you should include any"
+        " paths in between the project root and your config file.\n"
+        "E.g., `pipelines/lidar/config/dataset.yaml`"
+    )
+
+    overrides: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Overrides to apply to the config file referenced by `path`.\n"
+        "Overrides are defined in `key`: `value` pairs, where the `key` is a pointer to"
+        " the object in the config file to override and the `value` is what should"
+        " replace it.\n"
+        "The format of the keys is a cross between path-like structures and a python"
+        " dictionary. For example, to change the 'location_id' property on the python"
+        " object `obj = {'attrs': {'location_id': 'abc'}, 'data_vars': {...}}` to 'sgp'"
+        " you would write `/attrs/location_id: 'sgp'`.\n"
+        "Overrides are implemented using https://python-json-pointer.readthedocs.io/en/latest/tutorial.html",
+    )
 
     # def get_defaults_dict(self) -> Dict[Any, Any]:
     #     txt = self.path.read_text()


### PR DESCRIPTION
This PR adds some documentation for config overrides to the readthedocs page and to the yaml validation schema.