### PR TITLE
Allow FileSystemS3 to save multiple files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ h5netcdf
 pyarrow
 cftime
 xarray >=0.20
-act-atmos >=1.1.3
+act-atmos >=1.1.3,!=1.3.1,!=1.3.3
 pydantic >=1.9.0
 pyyaml >=5.4
 numpy >= 1.2


### PR DESCRIPTION
This PR fixes a bug with the new `CSVWriter` where it writes additional metadata and csv data files adjacent to the path it is provided, but the FileSystemS3 class does not know to preserve these extra files.