### PR TITLE
Refactor storage classes, fix QC

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,9 @@ jobs:
   tests:
     name: Run Test Suite
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
@@ -24,15 +27,9 @@ jobs:
           conda install -n base conda-libmamba-solver
           conda config --set solver libmamba
           conda env update --name tsdat --file environment.yml
-        shell: bash -el {0}
       - run: python -m pip install -e ".[dev]"
-        shell: bash -el {0}
       - run: conda info
-        shell: bash -el {0}
       - run: conda list
-        shell: bash -el {0}
       - run: coverage run -m pytest
-        shell: bash -el {0}
       - run: coverage xml
-        shell: bash -el {0}
       - uses: codecov/codecov-action@v2

--- a/.vscode/docstring.mustache
+++ b/.vscode/docstring.mustache
@@ -1,5 +1,4 @@
 {{! Tsdat Docstring Template }}
-------------------------------------------------------------------------------------
 {{summaryPlaceholder}}
 
 {{extendedSummaryPlaceholder}}
@@ -34,4 +33,3 @@ Yields:
     {{typePlaceholder}}: {{descriptionPlaceholder}}
 {{/yields}}
 {{/yieldsExist}}
-------------------------------------------------------------------------------------

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,9 @@
     "editor.formatOnSave": true,
     "yaml.format.printWidth": 88,
     "yaml.format.proseWrap": "always",
+    "black-formatter.args": [
+        "--preview"
+    ],
     "python.formatting.provider": "black",
     "python.linting.enabled": true,
     "python.linting.lintOnSave": true,
@@ -61,5 +64,5 @@
         "**/__pycache__": true,
         "**/*.pyc": true,
         "**/.mypy_cache": true,
-    }
+    },
 }

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@ coverage:
 	@ coverage run -m pytest
 	@ coverage html
 	@ echo "Run 'open htmlcov/index.html' to open it in your browser."
+
+.PHONY: docs
+docs:
+	@ (cd docs/ && make docs)

--- a/docs/source/config/hook_functions.rst
+++ b/docs/source/config/hook_functions.rst
@@ -33,17 +33,19 @@ output. Below is shown a custom plotting example:
 
         date, time = get_start_date_and_time_str(dataset)
 
-        plt.style.use("default")  # clear any styles that were set before
-        plt.style.use("shared/styling.mplstyle")
-
-        with self.storage.uploadable_dir(datastream) as tmp_dir:
+        with self.storage.uploadable_dir() as tmp_dir:
 
             fig, ax = plt.subplots()
             dataset["example_var"].plot(ax=ax, x="time")  # type: ignore
             fig.suptitle(f"Example Variable at {location} on {date} {time}")
             format_time_xticks(ax)
-            plot_file = get_filename(dataset, title="example_plot", extension="png")
-            fig.savefig(tmp_dir / plot_file)
+            plot_filepath = self.storage.get_ancillary_filepath(
+                title="example_plot",
+                extension="png",
+                root_dir=tmp_dir,
+                dataset=dataset,
+            )
+            fig.savefig(plot_filepath)
             plt.close(fig)
 
 

--- a/docs/source/tutorials/data_ingest.rst
+++ b/docs/source/tutorials/data_ingest.rst
@@ -725,7 +725,7 @@ desired:
   import cmocean
   import matplotlib.pyplot as plt
 
-  from tsdat import IngestPipeline, get_start_date_and_time_str, get_filename
+  from tsdat import IngestPipeline, get_start_date_and_time_str
 
 
   class NceiArcticCruiseExample(IngestPipeline):
@@ -747,38 +747,43 @@ desired:
 
       def hook_plot_dataset(self, dataset: xr.Dataset):
           location = self.dataset_config.attrs.location_id
-          datastream: str = self.dataset_config.attrs.datastream
 
           date, time = get_start_date_and_time_str(dataset)
 
           plt.style.use("default")  # clear any styles that were set before
           plt.style.use("shared/styling.mplstyle")
 
-        with self.storage.uploadable_dir(datastream) as tmp_dir:
+          with self.storage.uploadable_dir() as tmp_dir:
 
             fig, ax = plt.subplots()
             dataset["temperature"].plot(ax=ax, x="time", c=cmocean.cm.deep_r(0.5))
             fig.suptitle(f"Temperature measured at {location} on {date} {time}")
 
-            plot_file = get_filename(dataset, title="temperature", extension="png")
-            fig.savefig(tmp_dir / plot_file)
+            plot_file = self.storage.get_ancillary_filepath(
+                title="temperature",
+                extension="png",
+                root_dir=tmp_dir,
+                dataset=dataset,
+            )
+            fig.savefig(plot_file)
             plt.close(fig)
 
-            # Creat Plot Display
-            obj = dataset
+            # Create plot display using act
             variable = "wave_height"
             display = act.plotting.TimeSeriesDisplay(
-                obj, figsize=(15, 10), subplot_shape=(2,)
+                dataset, figsize=(15, 10), subplot_shape=(2,)
             )
-            # Plot data in top plot
-            display.plot(variable, subplot_index=(0,), label="Wave Height")
-            # Plot QC data
-            display.qc_flag_block_plot(variable, subplot_index=(1,))
-            fig = display.fig
+            display.plot(variable, subplot_index=(0,), label="Wave Height")  # data in top plot
+            display.qc_flag_block_plot(variable, subplot_index=(1,)) # qc in bottom plot
 
-            plot_file = get_filename(dataset, title="wave_height", extension="png")
-            fig.savefig(tmp_dir / plot_file)
-            plt.close(fig)
+            plot_file = self.storage.get_ancillary_filepath(
+                title=variable,
+                extension="png",
+                root_dir=tmp_dir,
+                dataset=dataset,
+            )
+            display.fig.savefig(plot_file)
+            plt.close(display.fig)
 
 
 

--- a/test/config/test_pipeline_config.py
+++ b/test/config/test_pipeline_config.py
@@ -32,6 +32,7 @@ def test_pipeline_config_merges_overrides():
         "quality": model_to_dict(quality),
         "storage": model_to_dict(storage),
     }
+    expected_dict["storage"]["parameters"]["data_storage_path"] = "data/{datastream}"
 
     # Load everything through the PipelineConfig
     pipeline_model = PipelineConfig.from_yaml(Path("test/config/yaml/pipeline.yaml"))

--- a/test/config/yaml/pipeline.yaml
+++ b/test/config/yaml/pipeline.yaml
@@ -19,3 +19,6 @@ quality:
 
 storage:
   path: test/config/yaml/storage.yaml
+  overrides:
+    /parameters:
+      data_storage_path: data/{datastream}

--- a/test/io/test_storage.py
+++ b/test/io/test_storage.py
@@ -264,9 +264,32 @@ def test_storage_saves_ancillary_files(
 
     expected_filepath = storage.parameters.storage_root / expected
 
+    # Normal method: use datastream and start time
     with storage.uploadable_dir() as tmp_dir:
         fpath = storage.get_ancillary_filepath(
-            title="ancillary", extension="png", dataset=dataset, root_dir=tmp_dir
+            title="ancillary",
+            extension="png",
+            datastream=dataset.attrs["datastream"],
+            start=dataset["time"].data[0],
+            root_dir=tmp_dir,
+        )
+        fpath.touch()
+    if storage_fixture == "s3_storage":
+        assert storage._exists(expected_filepath)
+        obj = storage._get_obj(expected_filepath)
+        assert obj is not None
+        obj.delete()
+    else:
+        assert expected_filepath.exists()
+        os.remove(expected_filepath)
+
+    # New method: extract needed info from the dataset object
+    with storage.uploadable_dir() as tmp_dir:
+        fpath = storage.get_ancillary_filepath(
+            title="ancillary",
+            extension="png",
+            dataset=dataset,
+            root_dir=tmp_dir,
         )
         fpath.touch()
     if storage_fixture == "s3_storage":

--- a/test/io/test_storage.py
+++ b/test/io/test_storage.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any

--- a/test/io/yaml/vap-storage.yaml
+++ b/test/io/yaml/vap-storage.yaml
@@ -1,3 +1,4 @@
 classname: tsdat.io.storage.FileSystem
 parameters:
   storage_root: test/io/data/retriever-store
+  data_storage_path: data/{datastream}

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -56,7 +56,7 @@ def test_ingest_pipeline():
 
     # Dataset saved to disk
     save_path = Path(
-        "storage/root/data/sgp/sgp.example.b1/sgp.example.b1.20220324.214300.nc"
+        "storage/root/data/sgp.example.b1/sgp.example.b1.20220324.214300.nc"
     )
     saved_dataset: xr.Dataset = xr.open_dataset(save_path)  # type: ignore
     assert_close(saved_dataset, expected)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -6,10 +6,10 @@ import pytest
 import xarray as xr
 
 from tsdat import PipelineConfig, assert_close
+from tsdat.pipeline.pipelines import TransformationPipeline
 
 
 def test_ingest_pipeline():
-
     expected = xr.Dataset(
         coords={
             "time": (
@@ -56,7 +56,7 @@ def test_ingest_pipeline():
 
     # Dataset saved to disk
     save_path = Path(
-        "storage/root/data/sgp.example.b1/sgp.example.b1.20220324.214300.nc"
+        "storage/root/data/sgp/sgp.example.b1/sgp.example.b1.20220324.214300.nc"
     )
     saved_dataset: xr.Dataset = xr.open_dataset(save_path)  # type: ignore
     assert_close(saved_dataset, expected)
@@ -70,7 +70,6 @@ def test_ingest_pipeline():
 
 @pytest.mark.requires_adi
 def test_transformation_pipeline():
-
     expected = xr.Dataset(
         coords={
             "time": (
@@ -98,7 +97,7 @@ def test_transformation_pipeline():
     )
 
     config = PipelineConfig.from_yaml(Path("test/io/yaml/vap-pipeline.yaml"))
-    pipeline = config.instantiate_pipeline()
+    pipeline: TransformationPipeline = config.instantiate_pipeline()
 
     inputs = ["20220405.000000", "20220406.000000"]
 

--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -49,6 +49,14 @@ def sample_dataset() -> xr.Dataset:
                     "_FillValue": -9999,
                 },
             ),
+            "other_var": (
+                "time",
+                np.array([59, 60, 61, 58], dtype=np.float64),  # type: ignore
+            ),
+            "other_var_r": (
+                "time",
+                np.array([58, 61, 60, 59], dtype=np.float64),  # type: ignore
+            ),
             "string_var": (
                 "time",
                 np.array(["foo", "", "", "bar"]),  # type: ignore
@@ -66,8 +74,10 @@ def sample_dataset() -> xr.Dataset:
         (CheckMissing, {}, "string_var", [False, True, True, False]),
         (CheckMonotonic, {}, "time", [False, False, False, False]),
         (CheckMonotonic, {"parameters": {"require_increasing": True}}, "time", [False, False, False, False]),
-        (CheckMonotonic, {"parameters": {"require_decreasing": True}}, "time", [True, True, True, True]),
+        (CheckMonotonic, {"parameters": {"require_decreasing": True}}, "time", [False, True, True, True]),
         (CheckMonotonic, {"parameters": {"dim": "time"}}, "monotonic_var", [False, False, False, False]),
+        (CheckMonotonic, {"parameters": {"dim": "time"}}, "other_var", [False, False, False, True]),
+        (CheckMonotonic, {"parameters": {"dim": "time"}}, "other_var_r", [False, True, True, True]),
         (CheckValidMin, {}, "monotonic_var", [True, False, False, False]),
         (CheckFailMin, {}, "monotonic_var", [True, False, False, False]),
         (CheckWarnMin, {}, "monotonic_var", [True, False, False, False]),

--- a/test/qc/test_qc.py
+++ b/test/qc/test_qc.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 from pytest import fixture
 
-from tsdat.qc.checkers import *
+from tsdat.qc.checkers import *  # type: ignore
 from tsdat.qc.handlers import *
 from tsdat.testing import assert_close
 
@@ -77,9 +77,7 @@ def test_missing_check(sample_dataset: xr.Dataset):
 
 
 def test_monotonic_check(sample_dataset: xr.Dataset):
-    new_sample_dataset = xr.concat(
-        (sample_dataset, sample_dataset), 
-        dim='time')
+    new_sample_dataset = xr.concat((sample_dataset, sample_dataset), dim="time")
 
     # either increasing or decreasing allowed
     checker = CheckMonotonic()
@@ -89,15 +87,13 @@ def test_monotonic_check(sample_dataset: xr.Dataset):
 
     # times must be increasing
     checker = CheckMonotonic(parameters={"require_increasing": True})  # type: ignore
-    expected = np.array([
-        False, False, False, False, True, True, True, True])
+    expected = np.array([False, False, False, False, True, True, True, True])
     results = checker.run(new_sample_dataset, "time")
     assert np.array_equal(results, expected)  # type: ignore
 
     # times must be decreasing
     checker = CheckMonotonic(parameters={"require_decreasing": True})  # type: ignore
-    expected = np.array(
-        [True, True, True, True, True, True, True, True])
+    expected = np.array([True, True, True, True, True, True, True, True])
     results = checker.run(new_sample_dataset, "time")
     assert np.array_equal(results, expected)  # type: ignore
 
@@ -276,7 +272,7 @@ def test_replace_failed_values(sample_dataset: xr.Dataset):
     assert_close(dataset, expected)
 
 
-def test_sortdataset_by_coordinate(sample_dataset: xr.Dataset):
+def test_sort_dataset_by_coordinate(sample_dataset: xr.Dataset):
     expected: xr.Dataset = sample_dataset.copy(deep=True)  # type: ignore
 
     # Sort by time, backwards
@@ -293,7 +289,6 @@ def test_sortdataset_by_coordinate(sample_dataset: xr.Dataset):
 
 
 def test_fail_pipeline_provides_useful_message(caplog: Any):
-
     ds = xr.Dataset(
         coords={
             "time": pd.date_range("2022-03-24 21:43:00", "2022-03-24 21:45:00", periods=3),  # type: ignore

--- a/test/test_tstring.py
+++ b/test/test_tstring.py
@@ -21,7 +21,7 @@ from tsdat.tstring import Template
         ("d.e-gf", "{a}.{b}[-g{c}][-{d}]", dict(a="d", b="e", c="f"), True),
     ),
 )
-def test_correctness(
+def test_substitutions(
     expected: str, template: str, mapping: Dict[str, str], allow_missing: bool
 ):
     assert Template(template).substitute(mapping, allow_missing) == expected
@@ -56,6 +56,91 @@ def test_failures(
 def test_overrides(expected: str, mapping: Dict[str, str], keywords: Dict[str, str]):
     template = Template("{a}.{b}[.{c}]")
     assert template.substitute(mapping, **keywords) == expected
+
+
+@pytest.mark.parametrize(
+    ("expected", "template", "formatted"),
+    (
+        (dict(a="b"), "{a}", "b"),
+        (dict(a="a", b="b", c="c"), "{a}.{b}.{c}", "a.b.c"),
+        (dict(a="a", b="b", c="c"), "{a}.{b}[.{c}]", "a.b.c"),
+        (dict(a="a", b="b", c="c"), "{a}[.{b}].{c}", "a.b.c"),
+        (dict(a="a", b="b", c="c"), "{a}.[{b}.]{c}", "a.b.c"),
+        (dict(a="a", b=None, c="c"), "{a}.[{b}.]{c}", "a.c"),
+        (dict(a="a", b="b", c="c"), "{a}[.de-{b}].{c}", "a.de-b.c"),
+        (dict(a="a", b="b", c="c"), "[{a}.]{b}.{c}", "a.b.c"),
+        (dict(a=None, b="b", c="c"), "[{a}.]{b}.{c}", "b.c"),
+        (dict(a="a", b=None, c="c"), "{a}[.{b}].{c}", "a.c"),
+        (
+            dict(var1="a", opt1="foo", var2="b"),
+            "{var1}[.{opt1}bar].{var2}",
+            "a.foobar.b",
+        ),
+        # test with actual datastream components
+        (
+            dict(
+                location_id="sgp",
+                dataset_name="lidar",
+                qualifier=None,
+                temporal=None,
+                data_level="a0",
+            ),
+            "{location_id}.{dataset_name}[-{qualifier}][-{temporal}].{data_level}",
+            "sgp.lidar.a0",
+        ),
+        (
+            dict(
+                location_id="sgp",
+                dataset_name="lidar",
+                qualifier="z01",
+                temporal="10m",
+                data_level="a0",
+            ),
+            "{location_id}.{dataset_name}[-{qualifier}][-{temporal}].{data_level}",
+            "sgp.lidar-z01-10m.a0",
+        ),
+        (
+            dict(
+                location_id="sgp",
+                dataset_name="lidar",
+                qualifier="z01",
+                temporal="10m",
+                data_level="a0",
+            ),
+            "{location_id}.{dataset_name}[::{qualifier}:][::{temporal}:].{data_level}",
+            "sgp.lidar::z01:::10m:.a0",  # weird format, just want an edge case
+        ),
+        (
+            dict(
+                location_id="sgp",
+                dataset_name="lidar",
+                z_id="z01",
+                temporal=None,
+                data_level="a0",
+            ),
+            "{location_id}.{dataset_name}.{z_id}[.{temporal}].{data_level}",
+            "sgp.lidar.z01.a0",
+        ),
+    ),
+)
+def test_regex_extractions(expected: dict[str, str], template: str, formatted: str):
+    _template = Template(template)
+    substitutions = _template.extract_substitutions(formatted)
+    assert substitutions == expected
+
+
+def test_manual_regex_extraction():
+    # ARM datastream
+    formatted = "mosthermocldphaseM1.c1"
+    template = Template(
+        "{location_id}{dataset_name}{facility}.{data_level}",
+        r"^(?P<location_id>[a-z]{3})(?P<dataset_name>[a-zA-Z0-9]+)(?P<facility>[A-Z]{1}[0-9]+)\.(?P<data_level>[a-z0-9]{1}[0-9]{1})$",
+    )
+    expected = dict(
+        location_id="mos", dataset_name="thermocldphase", facility="M1", data_level="c1"
+    )
+
+    assert template.extract_substitutions(formatted) == expected
 
 
 def test_repr():

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -1,6 +1,6 @@
-import tempfile
 import contextlib
-import xarray as xr
+import tempfile
+from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
 from typing import (
@@ -13,11 +13,13 @@ from typing import (
     Pattern,
     Union,
 )
-from abc import ABC, abstractmethod
-from pydantic import BaseModel, Extra, root_validator
-from ..utils import ParameterizedClass
-from ..config.dataset import DatasetConfig
 
+import xarray as xr
+from pydantic import BaseModel, BaseSettings, Extra, Field, root_validator, validator
+
+from ..config.dataset import DatasetConfig
+from ..tstring import Template
+from ..utils import ParameterizedClass, datetime_substitutions, get_fields_from_dataset
 
 __all__ = [
     "DataConverter",
@@ -133,7 +135,8 @@ class ArchiveReader(DataReader):
     Subclasses of `ArchiveHandler` may define additional parameters to support various
     methods of unpacking archived data.
 
-    ------------------------------------------------------------------------------------"""
+    ------------------------------------------------------------------------------------
+    """
 
     exclude: str = ""
 
@@ -181,6 +184,11 @@ class FileWriter(DataWriter, ABC):
 
     file_extension: str
 
+    @validator("file_extension")
+    @classmethod
+    def no_leading_dot(cls, v: str) -> str:
+        return v.lstrip(".")
+
     @abstractmethod
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any
@@ -221,15 +229,15 @@ class DataHandler(ParameterizedClass):
 
     @root_validator(pre=False)
     def patch_parameters(cls, values):
-        params = values.get('parameters', {})
-        writer_params = params.get('writer', {}) if params is not None else {}
-        reader_params = params.get('reader', {}) if params is not None else {}
+        params = values.get("parameters", {})
+        writer_params = params.get("writer", {}) if params is not None else {}
+        reader_params = params.get("reader", {}) if params is not None else {}
 
         for ky in writer_params:
-            setattr(values['writer'].parameters, ky, writer_params[ky])
+            setattr(values["writer"].parameters, ky, writer_params[ky])
         for ky in reader_params:
-            setattr(values['reader'].parameters, ky, reader_params[ky])
-        
+            setattr(values["reader"].parameters, ky, reader_params[ky])
+
         return values
 
 
@@ -248,6 +256,11 @@ class FileHandler(DataHandler):
     extension: str
     reader: DataReader
     writer: FileWriter
+
+    @validator("extension")
+    @classmethod
+    def no_leading_dot(cls, v: str) -> str:
+        return v.lstrip(".")
 
 
 # TODO: This needs a better name
@@ -328,15 +341,57 @@ class Storage(ParameterizedClass, ABC):
 
     ---------------------------------------------------------------------------------"""
 
-    parameters: Optional[Any]
-    """(Internal) parameters used by the storage API that can be set through
-    configuration files, environment variables, or other means."""
+    class Parameters(BaseSettings):
+        storage_root: Path = Field(Path("storage/root"), env="TSDAT_STORAGE_ROOT")
+        """The path on disk where at least ancillary files will be saved to. For
+        file-based storage classes this is also the root path for data files. Defaults
+        to the `storage/root` folder in the active working directory.
+        
+        NOTE: This parameter can also be set via the ``TSDAT_STORAGE_ROOT`` environment
+        variable."""
+
+        ancillary_storage_path: str = "ancillary/{location_id}/{datastream}"
+        """The directory structure under storage_root where ancillary files are saved.
+
+        Allows substitution of the following parameters using curly braces '{}':
+        
+        * ``extension``: the file extension (e.g., 'png', 'gif').
+        * ``datastream`` from the related xr.Dataset object's global attributes.
+        * ``location_id`` from the related xr.Dataset object's global attributes.
+        * ``data_level`` from the related xr.Dataset object's global attributes.
+        * ``year, month, day, hour, minute, second`` of the first timestamp in the data.
+        * ``date_time``: the first timestamp in the file formatted as "YYYYMMDD.hhmmss".
+        * The names of any other global attributes of the related xr.Dataset object.
+
+        Defaults to ``ancillary/{location_id}/{datastream}``."""
+
+        ancillary_filename_template: str = (
+            "{datastream}.{date_time}.{title}.{extension}"
+        )
+        """Template string to use for ancillary filenames.
+        
+        Allows substitution of the following parameters using curly braces '{}':
+        
+        * ``title``: a provided label for the ancillary file or plot.
+        * ``extension``: the file extension (e.g., 'png', 'gif').
+        * ``datastream`` from the related xr.Dataset object's global attributes.
+        * ``location_id`` from the related xr.Dataset object's global attributes.
+        * ``data_level`` from the related xr.Dataset object's global attributes.
+        * ``year, month, day, hour, minute, second`` of the first timestamp in the data.
+        * ``date_time``: the first timestamp in the file formatted as "YYYYMMDD.hhmmss".
+        * The names of any other global attributes of the related xr.Dataset object.
+        
+        At a minimum the template must include ``{date_time}``."""
+
+    parameters: Parameters = Field(default_factory=Parameters)  # type: ignore
+    """Parameters used by the storage API that can be set through configuration files,
+    environment variables, or directly."""
 
     handler: DataHandler
     """Defines methods for reading and writing datasets from the storage area."""
 
     @abstractmethod
-    def save_data(self, dataset: xr.Dataset):
+    def save_data(self, dataset: xr.Dataset, **kwargs: Any):
         """-----------------------------------------------------------------------------
         Saves the dataset to the storage area.
 
@@ -354,7 +409,14 @@ class Storage(ParameterizedClass, ABC):
     #     ...
 
     @abstractmethod
-    def fetch_data(self, start: datetime, end: datetime, datastream: str) -> xr.Dataset:
+    def fetch_data(
+        self,
+        start: datetime,
+        end: datetime,
+        datastream: str,
+        metadata_kwargs: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> xr.Dataset:
         """-----------------------------------------------------------------------------
         Fetches a dataset from the storage area.
 
@@ -365,6 +427,8 @@ class Storage(ParameterizedClass, ABC):
             start (datetime): The start time bound.
             end (datetime): The end time bound.
             datastream (str): The name of the datastream to fetch.
+            metadata_kwargs (dict[str, str], optional): Metadata substitutions to help
+                locate the data. This is often required for file-based storage classes.
 
         Returns:
             xr.Dataset: The fetched dataset.
@@ -372,44 +436,157 @@ class Storage(ParameterizedClass, ABC):
         -----------------------------------------------------------------------------"""
         ...
 
-    @abstractmethod
-    def save_ancillary_file(self, filepath: Path, datastream: str):
-        """-----------------------------------------------------------------------------
-        Saves an ancillary file to the storage area for the specified datastream.
+    def get_ancillary_filepath(
+        self,
+        title: str,
+        extension: str = "png",
+        dataset: xr.Dataset | None = None,
+        datastream: str | None = None,
+        start: datetime | None = None,
+        root_dir: Path | None = None,
+        mkdirs: bool = True,
+        **kwargs: str,
+    ) -> Path:
+        """Returns the filepath for the given datastream and title of an ancillary file
+        to be created.
 
-        Ancillary files are plots or other non-dataset metadata files.
+        This method is typically used in the plotting hook of pipelines to get the path
+        to where the plot file should be saved. In this case, it is recommend to use
+        this in conjunction with ``with self.storage.uploadable_dir() as tmp_dir`` and
+        use ``root_dir=tmp_dir`` as an argument to this function.
+
+        Example:
+
+            ```python
+            # in ``hook_plot_dataset(self, dataset: xr.Dataset)``
+            with self.storage.uploadable_dir() as tmp_dir:
+                fig, ax = plt.subplots()
+
+                # plotting code ...
+
+                plot_file = self.storage.get_ancillary_filepath(
+                    title="wind_speed",
+                    extension="png",
+                    root_dir=tmp_dir,
+                    dataset=dataset,
+                )
+                fig.savefig(plot_file)
+                plt.close(fig)
+            ```
 
         Args:
-            filepath (Path): Where the file that should be saved is currently located.
-            datastream (str): The datastream that the ancillary file is associated with.
+            title (str): The title of the ancillary file or plot. Should be lowercase
+                and use `_` instead of spaces.
+            extension (str): The file extension to be used. Defaults to "png".
+            dataset (xr.Dataset | None, optional): The dataset relating to the ancillary
+                file. If provided, this is used to populate defaults for the datastream,
+                start datetime, and other substitutions used to fill out the storage
+                path template. Values from these other fields, if present, will take
+                precedence.
+            datastream (str | None, optional): The datastream relating to the ancillary
+                file to be saved. Defaults to ``dataset.attrs["datastream"]``.
+            start (datetime | None, optional): The datetime relating to the ancillary
+                file to be saved. Defaults to ``dataset.time[0]``.
+            root_dir (Path | None, optional): The root directory. If using a temporary
+                (uploadable) directory, it is recommended to use that as the root_dir.
+                Defaults to None.
+            mkdirs (bool, optional): True if directories should be created, False
+                otherwise. Defaults to True.
+            **kwargs (str): Extra kwargs to use as substitutions for the ancillary
+                storage path or filename templates, which may require more parameters
+                than those already specified as arguments here. Defaults to
+                ``**dataset.attrs``.
 
-        -----------------------------------------------------------------------------"""
+        Returns:
+            Path: The path to the ancillary file.
+        """
+
+        # Override with provided substitutions and keywords, if provided
+        substitutions = get_fields_from_dataset(dataset)
+        substitutions.update(kwargs)
+        if datastream is not None:
+            substitutions["datastream"] = datastream
+        if start is not None:
+            substitutions.update(datetime_substitutions(start))
+        substitutions.update(extension=extension, ext=extension)
+
+        # Resolve substitutions to get ancillary filepath
+        dir_template = Template(self.parameters.ancillary_storage_path)
+        file_template = Template(self.parameters.ancillary_filename_template)
+        dirpath = dir_template.substitute(substitutions)
+        filename = file_template.substitute(substitutions, title=title)
+        ancillary_path = Path(dirpath) / filename
+        if root_dir is not None:
+            ancillary_path = root_dir / ancillary_path
+
+        if mkdirs:
+            ancillary_path.parent.mkdir(exist_ok=True, parents=True)
+
+        return ancillary_path
+
+    @abstractmethod
+    def save_ancillary_file(self, filepath: Path, target_path: Path | None = None):
+        """Saves an ancillary filepath to the datastream's ancillary storage area.
+
+        NOTE: In most cases this function should not be used directly. Instead, prefer
+        using the ``self.uploadable_dir(*args, **kwargs)`` method.
+
+        Args:
+            filepath (Path): The path to the ancillary file. This is expected to have
+                a standardized filename and should be saved under the ancillary storage
+                path.
+            target_path (str): The path to where the data should be saved.
+        """
         ...
 
     @contextlib.contextmanager
-    def uploadable_dir(self, datastream: str) -> Generator[Path, None, None]:
-        """-----------------------------------------------------------------------------
-        Context manager that can be used to upload many ancillary files at once.
+    def uploadable_dir(self, **kwargs: Any) -> Generator[Path, None, None]:
+        """Context manager that can be used to upload many ancillary files at once.
 
         This method yields the path to a temporary directory whose contents will be
         saved to the storage area using the save_ancillary_file method upon exiting the
         context manager.
 
+        Example:
+
+            ```python
+            # in ``hook_plot_dataset(self, dataset: xr.Dataset)``
+            with self.storage.uploadable_dir() as tmp_dir:
+                fig, ax = plt.subplots()
+
+                # plotting code ...
+
+                plot_file = self.storage.get_ancillary_filepath(
+                    title="wind_speed",
+                    extension="png",
+                    root_dir=tmp_dir,
+                    dataset=dataset,
+                )
+                fig.savefig(plot_file)
+                plt.close(fig)
+            ```
+
         Args:
-            datastream (str): The datastream associated with any files written to the
-                uploadable directory.
+            kwargs (Any): Unused. Included for backwards compatibility.
 
         Yields:
-            Generator[Path, None, None]: A temporary directory whose contents should be
-                saved to the storage area.
-
-        -----------------------------------------------------------------------------"""
+            Path: A temporary directory where files can be saved.
+        """
         tmp_dir = tempfile.TemporaryDirectory()
         tmp_dirpath = Path(tmp_dir.name)
+
         yield tmp_dirpath
 
         for path in tmp_dirpath.glob("**/*"):
             if path.is_file():
-                self.save_ancillary_file(path, datastream)
+                # Users are expected to call self.get_ancillary_filename() with
+                # root_dir=tmp_dir (yield value from this function) or save files to
+                # tmp_dir / filename (using root_dir=None, the default, for
+                # get_ancillary_filename()).
+                #
+                # With these assumptions, we can get the target filepath by replacing
+                # tmp_dir with self.parameters.storage_root
+                target = self.parameters.storage_root / path.relative_to(tmp_dirpath)
+                self.save_ancillary_file(path, target_path=target)
 
         tmp_dir.cleanup()

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -11,6 +11,7 @@ from typing import (
     NamedTuple,
     Optional,
     Pattern,
+    Tuple,
     Union,
 )
 
@@ -386,6 +387,36 @@ class Storage(ParameterizedClass, ABC):
 
     handler: DataHandler
     """Defines methods for reading and writing datasets from the storage area."""
+    
+    def last_modified(self, datastream:str) -> Union[datetime, None]:
+        """Find the last modified time for any data in that datastream.
+
+        Args:
+            datstream (str): _description_
+
+        Returns:
+            _type_: _description_
+
+        Yields:
+            _type_: _description_
+        """
+        return None
+
+    def modified_since(self, datastream: str, last_modified: datetime) -> List[datetime]:
+        """Find the list of data dates that have been modified since the passed
+        last modified date.
+
+        Args:
+            datastream (str): _description_
+            last_modified (datetime): Should be equivalent to run date (the last time data were changed)
+
+        Returns:
+            List[datetime]: The data dates of files that were changed since the last modified date
+
+        Yields:
+            _type_: _description_
+        """
+        return []
 
     @abstractmethod
     def save_data(self, dataset: xr.Dataset, **kwargs: Any):

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -535,15 +535,16 @@ class Storage(ParameterizedClass, ABC):
         """
 
         # Override with provided substitutions and keywords, if provided
-        substitutions = get_fields_from_dataset(dataset)
-        substitutions.update(kwargs)
+        substitutions = {}
+        if dataset is not None:
+            substitutions.update(get_fields_from_dataset(dataset))
         if datastream is not None:
-            substitutions["datastream"] = datastream
-            substitutions.update(get_fields_from_datastream(datastream))
+            substitutions.update(
+                datastream=datastream, **get_fields_from_datastream(datastream)
+            )
         if start is not None:
             substitutions.update(datetime_substitutions(start))
-        substitutions.update(extension=extension, ext=extension)
-        substitutions["title"] = title
+        substitutions.update(extension=extension, ext=extension, title=title, **kwargs)
 
         # Resolve substitutions to get ancillary filepath
         dir_template = Template(self.parameters.ancillary_storage_path)

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -485,7 +485,8 @@ class Storage(ParameterizedClass, ABC):
 
         Example:
 
-            ```python
+        .. code-block:: python
+
             # in ``hook_plot_dataset(self, dataset: xr.Dataset)``
             with self.storage.uploadable_dir() as tmp_dir:
                 fig, ax = plt.subplots()
@@ -500,7 +501,6 @@ class Storage(ParameterizedClass, ABC):
                 )
                 fig.savefig(plot_file)
                 plt.close(fig)
-            ```
 
         Args:
             title (str): The title of the ancillary file or plot. Should be lowercase
@@ -577,7 +577,8 @@ class Storage(ParameterizedClass, ABC):
 
         Example:
 
-            ```python
+        .. code-block:: python
+
             # in ``hook_plot_dataset(self, dataset: xr.Dataset)``
             with self.storage.uploadable_dir() as tmp_dir:
                 fig, ax = plt.subplots()
@@ -592,7 +593,6 @@ class Storage(ParameterizedClass, ABC):
                 )
                 fig.savefig(plot_file)
                 plt.close(fig)
-            ```
 
         Args:
             kwargs (Any): Unused. Included for backwards compatibility.

--- a/tsdat/io/handlers.py
+++ b/tsdat/io/handlers.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from .base import FileHandler
 from .readers import NetCDFReader, CSVReader, ParquetReader, ZarrReader
 from .writers import (
@@ -19,29 +20,29 @@ __all__ = [
 
 class NetCDFHandler(FileHandler):
     extension: str = "nc"
-    reader: NetCDFReader = NetCDFReader()
-    writer: NetCDFWriter = NetCDFWriter()
+    reader: NetCDFReader = Field(default_factory=NetCDFReader)
+    writer: NetCDFWriter = Field(default_factory=NetCDFWriter)
 
 
 class SplitNetCDFHandler(FileHandler):
     extension: str = "nc"
-    reader: NetCDFReader = NetCDFReader()
-    writer: SplitNetCDFWriter = SplitNetCDFWriter()
+    reader: NetCDFReader = Field(default_factory=NetCDFReader)
+    writer: SplitNetCDFWriter = Field(default_factory=SplitNetCDFWriter)
 
 
 class CSVHandler(FileHandler):
     extension: str = "csv"
-    reader: CSVReader = CSVReader()
-    writer: CSVWriter = CSVWriter()
+    reader: CSVReader = Field(default_factory=CSVReader)
+    writer: CSVWriter = Field(default_factory=CSVWriter)
 
 
 class ParquetHandler(FileHandler):
     extension: str = "parquet"
-    reader: ParquetReader = ParquetReader()
-    writer: ParquetWriter = ParquetWriter()
+    reader: ParquetReader = Field(default_factory=ParquetReader)
+    writer: ParquetWriter = Field(default_factory=ParquetWriter)
 
 
 class ZarrHandler(FileHandler):
     extension: str = "zarr"
-    reader: ZarrReader = ZarrReader()
-    writer: ZarrWriter = ZarrWriter()
+    reader: ZarrReader = Field(default_factory=ZarrReader)
+    writer: ZarrWriter = Field(default_factory=ZarrWriter)

--- a/tsdat/io/handlers.py
+++ b/tsdat/io/handlers.py
@@ -18,30 +18,30 @@ __all__ = [
 
 
 class NetCDFHandler(FileHandler):
-    extension: str = ".nc"
+    extension: str = "nc"
     reader: NetCDFReader = NetCDFReader()
     writer: NetCDFWriter = NetCDFWriter()
 
 
 class SplitNetCDFHandler(FileHandler):
-    extension: str = ".nc"
+    extension: str = "nc"
     reader: NetCDFReader = NetCDFReader()
     writer: SplitNetCDFWriter = SplitNetCDFWriter()
 
 
 class CSVHandler(FileHandler):
-    extension: str = ".csv"
+    extension: str = "csv"
     reader: CSVReader = CSVReader()
     writer: CSVWriter = CSVWriter()
 
 
 class ParquetHandler(FileHandler):
-    extension: str = ".parquet"
+    extension: str = "parquet"
     reader: ParquetReader = ParquetReader()
     writer: ParquetWriter = ParquetWriter()
 
 
 class ZarrHandler(FileHandler):
-    extension: str = ".zarr"
+    extension: str = "zarr"
     reader: ZarrReader = ZarrReader()
     writer: ZarrWriter = ZarrWriter()

--- a/tsdat/io/storage.py
+++ b/tsdat/io/storage.py
@@ -64,6 +64,7 @@ class FileSystem(Storage):
         * ``datastream`` from the dataset's global attributes
         * ``location_id`` from the dataset's global attributes
         * ``data_level`` from the dataset's global attributes
+        * ``date_time``: the first timestamp in the file formatted as "YYYYMMDD.hhmmss"
         * Any other global attribute that has a string or integer data type.
         
         At a minimum the template must include ``{date_time}``.

--- a/tsdat/io/storage.py
+++ b/tsdat/io/storage.py
@@ -1,121 +1,73 @@
 import logging
+import re
 import shutil
 import tempfile
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from time import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
-import boto3
-import botocore.exceptions
 import xarray as xr
-from pydantic import BaseSettings, Field, root_validator, validator
+from pydantic import Field, validator
 from tsdat.tstring import Template
 
-from ..utils import get_fields_from_datastream, get_filename, get_fields_from_dataset
+from ..utils import get_fields_from_dataset
 from .base import Storage
 from .handlers import FileHandler, NetCDFHandler, ZarrHandler
 
 __all__ = ["FileSystem", "FileSystemS3", "ZarrLocalStorage"]
 
-# IDEA: interval / split files apart by some timeframe (e.g., 1 day)
-#
-# Optional:
-# file_timespan: 1D
-#
-#
-# psuedocode: Solely for splitting up a file into multiple chunks. Searching for
-# previous + merging probably happens when you actually store the dataset, if that's
-# something we care about
 
-# start_time = 00:00:00 (midnight for the date of the first timestamp in the dataset)
-# first_interval = [start_time: start_time + file_time_interval]
-# start_time += file_time_interval
-# until start_time + file_time_interval >= timestamp of the last point of the dataset
 logger = logging.getLogger(__name__)
 
 
 class FileSystem(Storage):
-    """------------------------------------------------------------------------------------
-    Handles data storage and retrieval for file-based data formats.
+    """Handles data storage and retrieval for file-based data formats.
 
     Formats that write to directories (such as zarr) are not supported by the FileSystem
     storage class.
 
     Args:
-        parameters (Parameters): File-system specific parameters, such as the root path to
-            where files should be saved, or additional keyword arguments to specific
-            functions used by the storage API. See the FileSystemStorage.Parameters class for
-            more details.
+        parameters (Parameters): File-system specific parameters, such as the root path
+            to where files should be saved, or additional keyword arguments to specific
+            functions used by the storage API. See the FileSystemStorage.Parameters
+            class for more details.
         handler (FileHandler): The FileHandler class that should be used to handle data
             I/O within the storage API.
+    """
 
-    ------------------------------------------------------------------------------------"""
-
-    # TODO: @clansing refactor to use a 'StorageFile' class for custom file naming
-    # conventions. Until then, we will assume that we are using tsdat naming conventions
-    # e.g., datastream = location.dataset_name[-qualifier][-temporal].data_level,
-    # filename = datastream.YYYYMMDD.hhmmss.<extension>
-    # filepath = <storage root>/location/datastream/filename
-    # NOTE: StorageFile or similar work will likely require the dataset object or dataset
-    # config object, which means fetch data and other methods that need to search for data
-    # will also need to be provided with this info.
-
-    class Parameters(BaseSettings):
-        storage_root: Path = Path.cwd() / "storage" / "root"
-        """The path on disk where data and ancillary files will be saved to. Defaults to
-        the `storage/root` folder in the active working directory. The directory is
-        created as this parameter is set, if the directory does not already exist."""
-
-        data_folder: Path = Field(Path("data"))
-        """The directory under storage_root/ where datastream data folders and files
-        should be saved to. Defaults to `data/`."""
-
-        ancillary_folder: Path = Path("ancillary")
-        """The directory under storage_root/ where datastream ancillary folders and
-        files should be saved to. This is primarily used for plots. Defaults to
-        `ancillary/`."""
-
-        data_storage_path: Path = Path("{storage_root}/{data_folder}/{datastream}")
-        """The directory structure that should be used when data files are saved. Allows
-        substitution of the following parameters using curly braces '{}':
+    class Parameters(Storage.Parameters):
+        data_storage_path: Path = Path("data/{location_id}/{datastream}")
+        """The directory structure under storage_root where ancillary files are saved.
+        
+        Allows substitution of the following parameters using curly braces '{}':
         
         * ``storage_root``: the value from the ``storage_root`` parameter.
-        * ``data_folder``:  the value from the ``data_folder`` parameter.
-        * ``ancillary_folder``:  the value from the ``ancillary_folder`` parameter.
-        * ``datastream``: the ``datastream`` as defined in the dataset configuration file.
-        * ``location_id``: the ``location_id`` as defined in the dataset configuration file.
-        * ``data_level``: the ``data_level`` as defined in the dataset configuration file.
+        * ``datastream``: the ``datastream`` as defined in the dataset config file.
+        * ``location_id``: the ``location_id`` as defined in the dataset config file.
+        * ``data_level``: the ``data_level`` as defined in the dataset config file.
         * ``year``: the year of the first timestamp in the file.
         * ``month``: the month of the first timestamp in the file.
         * ``day``: the day of the first timestamp in the file.
         * ``extension``: the file extension used by the output file writer.
 
-        Defaults to ``{storage_root}/{data_folder}/{datastream}``.
+        Defaults to ``data/{location_id}/{datastream}``.
         """
 
-        ancillary_storage_path: Path = Path(
-            "{storage_root}/{ancillary_folder}/{datastream}"
-        )
-        """The directory structure that should be used when ancillary files are saved.
+        data_filename_template: str = "{datastream}.{date_time}.{extension}"
+        """Template string to use for data filenames.
+        
         Allows substitution of the following parameters using curly braces '{}':
         
-        * ``storage_root``: the value from the ``storage_root`` parameter.
-        * ``data_folder``:  the value from the ``data_folder`` parameter.
-        * ``ancillary_folder``:  the value from the ``ancillary_folder`` parameter.
-        * ``datastream``: the ``datastream`` as defined in the dataset configuration file.
-        * ``location_id``: the ``location_id`` as defined in the dataset configuration file.
-        * ``data_level``: the ``data_level`` as defined in the dataset configuration file.
-        * ``ext``: the file extension (e.g., 'png', 'gif').
-        * ``year``: the year of the first timestamp in the file.
-        * ``month``: the month of the first timestamp in the file.
-        * ``day``: the day of the first timestamp in the file.
-
-        Defaults to ``{storage_root}/{ancillary_folder}/{datastream}``.
+        * ``ext``: the file extension from the storage data handler
+        * ``datastream`` from the dataset's global attributes
+        * ``location_id`` from the dataset's global attributes
+        * ``data_level`` from the dataset's global attributes
+        * Any other global attribute that has a string or integer data type.
+        
+        At a minimum the template must include ``{date_time}``.
         """
-
-        file_timespan: Optional[str] = None  # Unused
 
         merge_fetched_data_kwargs: Dict[str, Any] = dict()
         """Keyword arguments passed to xr.merge.
@@ -130,33 +82,26 @@ class FileSystem(Storage):
                 storage_root.mkdir(parents=True)
             return storage_root
 
-        @root_validator()
-        def _resolve_static_substitutions(
-            cls, values: Dict[str, Any]
-        ) -> Dict[str, Any]:
-            substitutions = {
-                "storage_root": str(values["storage_root"]),
-                "data_folder": str(values["data_folder"]),
-                "ancillary_folder": str(values["ancillary_folder"]),
-            }
-
-            values["data_storage_path"] = Path(
-                Template(str(values["data_storage_path"])).substitute(
-                    substitutions, allow_missing=True
-                )
-            )
-            values["ancillary_storage_path"] = Path(
-                Template(str(values["ancillary_storage_path"])).substitute(
-                    substitutions, allow_missing=True
-                )
-            )
-
-            return values
-
     parameters: Parameters = Field(default_factory=Parameters)  # type: ignore
     handler: FileHandler = Field(default_factory=NetCDFHandler)
 
-    def save_data(self, dataset: xr.Dataset):
+    def save_ancillary_file(self, filepath: Path, target_path: Path | None = None):
+        """Saves an ancillary filepath to the datastream's ancillary storage area.
+
+        NOTE: In most cases this function should not be used directly. Instead, prefer
+        using the ``self.uploadable_dir(*args, **kwargs)`` method.
+
+        Args:
+            filepath (Path): The path to the ancillary file. This is expected to have
+                a standardized filename and should be saved under the ancillary storage
+                path.
+            target_path (str): The path to where the data should be saved.
+        """
+        target_path.parent.mkdir(exist_ok=True, parents=True)
+        saved_filepath = shutil.copy2(filepath, target_path)
+        logger.info("Saved ancillary file to: %s", saved_filepath)
+
+    def save_data(self, dataset: xr.Dataset, **kwargs: Any):
         """-----------------------------------------------------------------------------
         Saves a dataset to the storage area.
 
@@ -173,63 +118,79 @@ class FileSystem(Storage):
         self.handler.writer.write(dataset, filepath)
         logger.info("Saved %s dataset to %s", datastream, filepath.as_posix())
 
-    def fetch_data(self, start: datetime, end: datetime, datastream: str) -> xr.Dataset:
+    def fetch_data(
+        self,
+        start: datetime,
+        end: datetime,
+        datastream: str,
+        metadata_kwargs: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> xr.Dataset:
         """-----------------------------------------------------------------------------
         Fetches data for a given datastream between a specified time range.
-
-        Note: this method is not smart; it searches for the appropriate data files using
-        their filenames and does not filter within each data file.
 
         Args:
             start (datetime): The minimum datetime to fetch.
             end (datetime): The maximum datetime to fetch.
             datastream (str): The datastream id to search for.
+            metadata_kwargs (dict[str, str], optional): Metadata substitutions to help
+                resolve the data storage path. This is required if the template data
+                storage path includes any properties other than datastream. Defaults to
+                None.
 
         Returns:
             xr.Dataset: A dataset containing all the data in the storage area that spans
             the specified datetimes.
 
         -----------------------------------------------------------------------------"""
-        data_files = self._find_data(start, end, datastream)
-        datasets = self._open_data_files(*data_files)
-        return xr.merge(datasets, **self.parameters.merge_fetched_data_kwargs)  # type: ignore
-
-    def save_ancillary_file(self, filepath: Path, datastream: str):
-        """-----------------------------------------------------------------------------
-        Saves an ancillary filepath to the datastream's ancillary storage area.
-
-        Args:
-            filepath (Path): The path to the ancillary file.
-            datastream (str): The datastream that the file is related to.
-
-        -----------------------------------------------------------------------------"""
-        ancillary_filepath = self._get_ancillary_filepath(filepath, datastream)
-        ancillary_filepath.parent.mkdir(exist_ok=True, parents=True)
-        saved_filepath = shutil.copy2(filepath, ancillary_filepath)
-        logger.info("Saved ancillary file to: %s", saved_filepath)
-
-    def _find_data(self, start: datetime, end: datetime, datastream: str) -> List[Path]:
-        unresolved = self.parameters.data_storage_path.as_posix()
-        extension = self.handler.writer.file_extension
-        extension = extension if not extension.startswith(".") else extension[1:]
-        semi_resolved = Template(unresolved).substitute(
-            get_fields_from_datastream(datastream),
-            allow_missing=True,
-            extension=extension,
+        data_files = self._find_data(
+            start,
+            end,
+            datastream,
+            metadata_kwargs=metadata_kwargs if metadata_kwargs is not None else {},
         )
-        root_path, pattern = self._extract_time_substitutions(semi_resolved, start, end)
-        filepaths = list(root_path.glob(pattern))  # FIXME
+        datasets = self._open_data_files(*data_files)
+        dataset = xr.merge(datasets, **self.parameters.merge_fetched_data_kwargs)  # type: ignore
+        if not dataset:
+            logger.warning(
+                "No data found for %s in range %s - %s", datastream, start, end
+            )
+            return dataset  # empty
+        return dataset.sel(time=slice(start, end))
+
+    def _find_data(
+        self,
+        start: datetime,
+        end: datetime,
+        datastream: str,
+        metadata_kwargs: dict[str, str],
+        **kwargs: Any,
+    ) -> List[Path]:
+        dir_template = Template(self.parameters.data_storage_path.as_posix())
+        extension = self.handler.writer.file_extension
+        semi_resolved = dir_template.substitute(
+            dict(
+                datastream=datastream,
+                extension=extension,
+                ext=extension,
+                **metadata_kwargs,
+            ),
+            allow_missing=True,
+        )
+        dirpath, pattern = self._extract_time_substitutions(semi_resolved, start, end)
+        dirpath = self.parameters.storage_root / dirpath
+        filepaths = (p for p in dirpath.glob(pattern))
         return self._filter_between_dates(filepaths, start, end)
 
     def _filter_between_dates(
-        self, filepaths: List[Path], start: datetime, end: datetime
+        self, filepaths: Iterable[Path], start: datetime, end: datetime
     ) -> List[Path]:
-        # HACK: Currently can overshoot on both sides of the given range because we only
-        # use the start date from the filename.
         def __get_date_str(file: Path) -> str:
-            name_components = file.name.split(".")
-            date_components = name_components[3:5]
-            return ".".join(date_components)
+            datetime_match = re.match(r".*(\d{8}\.\d{6}).*", file.name)
+            if datetime_match is not None:
+                return datetime_match.groups()[0]
+            logger.error(f"File {file} does not contain a recognized date string")
+            return ""
 
         start_date_str = start.strftime("%Y%m%d.%H%M%S")
         end_date_str = end.strftime("%Y%m%d.%H%M%S")
@@ -250,84 +211,17 @@ class FileSystem(Storage):
             dataset_list.append(data)
         return dataset_list
 
-    def _substitute_ancillary_filepath_parts(
-        self, filepath: Path, datastream: Optional[str]
-    ) -> Path:
-        ancillary_stub_path = Template(
-            self.parameters.ancillary_storage_path.as_posix()
-        )
-
-        start: Optional[datetime] = None
-
-        try:
-            # TODO: Extract logic for splitting filepath/name into component parts
-            # Filepath should be like loc.name[-qual][temp].lvl.date.time[.title].ext
-            #                         ^^^^^^ datastream ^^^^^^^
-            filename_parts = filepath.name.split(".")
-            assert len(filename_parts) >= 5
-
-            loc_id = filename_parts[0]
-            # dataset_name = filename_parts[1].split("-")[0]
-            data_level = filename_parts[2]
-            datastream = datastream or ".".join(filename_parts[:3])
-            start_date_time = ".".join(filename_parts[3:5])
-            start = datetime.strptime(start_date_time, "%Y%m%d.%H%M%S")
-        except AssertionError:  # filename not standardized; require datastream
-            logger.warning(
-                "Attempting to store file with unstandardized filename. This will be"
-                " deprecated in a future release of tsdat. Please use"
-                " `tsdat.utils.get_filename()` to get a standardized filename for your"
-                " ancillary file."
-            )
-            if datastream is None:
-                raise ValueError(
-                    "Argument 'datastream' must be provided to the"
-                    " 'save_ancillary_file()' method if not saving an ancillary file"
-                    " with a tsdat-standardized name."
-                )
-            loc_id, _, data_level = datastream.split(".")
-
-        def get_time_fmt(fmt: str) -> str:
-            if start is None:
-                raise ValueError(
-                    f"Substitution '{fmt}' cannot be used with an unstandardized"
-                    " filename. Please modify the `ancillary_storage_path` config"
-                    " parameter or use `tsdat.utils.get_filename()` to get a"
-                    " standardized filename for your ancillary file."
-                )
-            return start.strftime(fmt)
-
-        return Path(
-            ancillary_stub_path.substitute(
-                datastream=datastream,
-                location_id=loc_id,
-                data_level=data_level,
-                ext=filepath.suffix,
-                year=lambda: get_time_fmt("%Y"),
-                month=lambda: get_time_fmt("%m"),
-                day=lambda: get_time_fmt("%d"),
-            )
-        )
-
     def _get_dataset_filepath(self, dataset: xr.Dataset) -> Path:
-        data_stub_path = Template(self.parameters.data_storage_path.as_posix())
         extension = self.handler.writer.file_extension
-        extension = extension if not extension.startswith(".") else extension[1:]
-        datastream_dir = Path(
-            data_stub_path.substitute(
-                get_fields_from_dataset(dataset),
-                extension=extension,
-            )
-        )
-        return datastream_dir / get_filename(dataset, extension)
+        substitutions = get_fields_from_dataset(dataset)
+        substitutions.update(extension=extension, ext=extension)
 
-    def _get_ancillary_filepath(
-        self, filepath: Path, datastream: Optional[str] = None
-    ) -> Path:
-        return (
-            self._substitute_ancillary_filepath_parts(filepath, datastream=datastream)
-            / filepath.name
-        )
+        dir_template = Template(self.parameters.data_storage_path.as_posix())
+        filename_template = Template(self.parameters.data_filename_template)
+        dirpath = dir_template.substitute(substitutions)
+        filename = filename_template.substitute(substitutions)
+
+        return self.parameters.storage_root / dirpath / filename
 
     def _extract_time_substitutions(
         self, template_str: str, start: datetime, end: datetime
@@ -344,34 +238,22 @@ class FileSystem(Storage):
 
 
 class FileSystemS3(FileSystem):
-    """------------------------------------------------------------------------------------
-    Handles data storage and retrieval for file-based data formats in an AWS S3 bucket.
+    """Handles data storage and retrieval for file-based data in an AWS S3 bucket.
 
     Args:
-        parameters (Parameters): File-system and AWS-specific parameters, such as the root
-            path to where files should be saved, or additional keyword arguments to
+        parameters (Parameters): File-system and AWS-specific parameters, such as the
+            path to where files should be saved or additional keyword arguments to
             specific functions used by the storage API. See the FileSystemS3.Parameters
             class for more details.
         handler (FileHandler): The FileHandler class that should be used to handle data
             I/O within the storage API.
-
-    ------------------------------------------------------------------------------------"""
+    """
 
     class Parameters(FileSystem.Parameters):  # type: ignore
         """Additional parameters for S3 storage.
 
         Note that all settings and parameters from ``Filesystem.Parameters`` are also
         supported by ``FileSystemS3.Parameters``."""
-
-        storage_root: Path = Field(Path("storage/root"), env="TSDAT_STORAGE_ROOT")
-        """The path on disk where data and ancillary files will be saved to.
-        
-        Note:
-            This parameter can also be set via the ``TSDAT_STORAGE_ROOT`` environment
-            variable.
-
-        Defaults to the ``storage/root`` folder in the top level of the storage bucket.
-        """
 
         bucket: str = Field("tsdat-storage", env="TSDAT_S3_BUCKET_NAME")
         """The name of the S3 bucket that the storage class should use.
@@ -390,10 +272,6 @@ class FileSystemS3(FileSystem):
         
         Defaults to ``us-west-2``."""
 
-        merge_fetched_data_kwargs: Dict[str, Any] = dict()
-        """Keyword arguments to xr.merge. This will only be called if the
-        DataReader returns a dictionary of xr.Datasets for a single saved file."""
-
         @validator("storage_root")
         def _ensure_storage_root_exists(cls, storage_root: Path) -> Path:
             return storage_root  # HACK: Don't run parent validator to create storage root file
@@ -402,6 +280,8 @@ class FileSystemS3(FileSystem):
 
     @validator("parameters")
     def _check_authentication(cls, parameters: Parameters):
+        import botocore.exceptions
+
         session = FileSystemS3._get_session(
             region=parameters.region, timehash=FileSystemS3._get_timehash()
         )
@@ -416,6 +296,8 @@ class FileSystemS3(FileSystem):
 
     @validator("parameters")
     def _ensure_bucket_exists(cls, parameters: Parameters):
+        import botocore.exceptions
+
         session = FileSystemS3._get_session(
             region=parameters.region, timehash=FileSystemS3._get_timehash()
         )
@@ -454,7 +336,10 @@ class FileSystemS3(FileSystem):
         Returns:
             boto3.session.Session: An active boto3 Session object.
 
-        ------------------------------------------------------------------------------------"""
+        ------------------------------------------------------------------------------------
+        """
+        import boto3
+
         del timehash
         return boto3.session.Session(region_name=region)
 
@@ -462,39 +347,66 @@ class FileSystemS3(FileSystem):
     def _get_timehash(seconds: int = 3600) -> int:
         return round(time() / seconds)
 
-    def save_data(self, dataset: xr.Dataset):
+    def save_ancillary_file(self, filepath: Path, target_path: Path | None = None):
+        """Saves an ancillary filepath to the datastream's ancillary storage area.
+
+        NOTE: In most cases this function should not be used directly. Instead, prefer
+        using the ``self.uploadable_dir(*args, **kwargs)`` method.
+
+        Args:
+            filepath (Path): The path to the ancillary file. This is expected to have
+                a standardized filename and should be saved under the ancillary storage
+                path.
+            target_path (str): The path to where the data should be saved.
+        """
+        self._bucket.upload_file(Filename=str(filepath), Key=target_path.as_posix())
+        logger.info("Saved ancillary file to: %s", target_path.as_posix())
+
+    def save_data(self, dataset: xr.Dataset, **kwargs: Any):
         datastream: str = dataset.attrs["datastream"]
         standard_fpath = self._get_dataset_filepath(dataset)
-
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_filepath = Path(tmp_dir) / standard_fpath
-            tmp_filepath.parent.mkdir(parents=True, exist_ok=True)
-
+            tmp_filepath = Path(tmp_dir) / standard_fpath.name
             self.handler.writer.write(dataset, tmp_filepath)
-
             for filepath in Path(tmp_dir).glob("**/*"):
                 if filepath.is_dir():
                     continue
-                s3_filepath = filepath.relative_to(tmp_dir).as_posix()
-                self._bucket.upload_file(Filename=filepath.as_posix(), Key=s3_filepath)
+                s3_key = (
+                    standard_fpath.parent / filepath.relative_to(tmp_dir)
+                ).as_posix()
+                self._bucket.upload_file(Filename=filepath.as_posix(), Key=s3_key)
                 logger.info(
                     "Saved %s data file to s3://%s/%s",
                     datastream,
                     self.parameters.bucket,
-                    s3_filepath,
+                    s3_key,
                 )
 
-    def save_ancillary_file(self, filepath: Path, datastream: str):
-        s3_filepath = self._get_ancillary_filepath(filepath, datastream)
-        self._bucket.upload_file(Filename=str(filepath), Key=str(s3_filepath))
-        logger.info("Saved %s ancillary file to: %s", filepath.name, str(s3_filepath))
+    def _find_data(
+        self,
+        start: datetime,
+        end: datetime,
+        datastream: str,
+        metadata_kwargs: dict[str, str],
+        **kwargs: Any,
+    ) -> List[Path]:
+        dir_template = Template(self.parameters.data_storage_path.as_posix())
+        extension = self.handler.writer.file_extension
+        semi_resolved = dir_template.substitute(
+            dict(
+                datastream=datastream,
+                extension=extension,
+                ext=extension,
+                **metadata_kwargs,
+            ),
+            allow_missing=True,
+        )
+        dirpath, pattern = self._extract_time_substitutions(semi_resolved, start, end)
+        dirpath = self.parameters.storage_root / dirpath
+        pattern = pattern.replace("*", ".*")
 
-    def _find_data(self, start: datetime, end: datetime, datastream: str) -> List[Path]:
-        prefix = str(self.parameters.storage_root / "data" / datastream) + "/"
-        objects = self._bucket.objects.filter(Prefix=prefix)
-        filepaths = [
-            Path(obj.key) for obj in objects if obj.key.endswith(self.handler.extension)
-        ]
+        objects = self._bucket.objects.filter(Prefix=dirpath.as_posix())
+        filepaths = (Path(p.key) for p in objects if re.search(pattern, p.key))
         return self._filter_between_dates(filepaths, start, end)
 
     def _open_data_files(self, *filepaths: Path) -> List[xr.Dataset]:
@@ -509,7 +421,7 @@ class FileSystemS3(FileSystem):
                 data = self.handler.reader.read(tmp_filepath)
                 if isinstance(data, dict):
                     data = xr.merge(data.values())  # type: ignore
-                data = data.compute()  # type: ignore
+                data = data.load()  # type: ignore
                 dataset_list.append(data)
         return dataset_list
 
@@ -545,85 +457,45 @@ class ZarrLocalStorage(FileSystem):
     ---------------------------------------------------------------------------------"""
 
     class Parameters(FileSystem.Parameters):
-        data_storage_path: Path = Path(
-            "{storage_root}/{data_folder}"  # /{datastream}.{extension}
-        )
-        """The directory structure that should be used when data files are saved. Allows
-        substitution of the following parameters using curly braces '{}':
+        data_storage_path: Path = Path("data/{location_id}")
+        """The directory structure under storage_root where ancillary files are saved.
+        
+        Allows substitution of the following parameters using curly braces '{}':
         
         * ``storage_root``: the value from the ``storage_root`` parameter.
-        * ``data_folder``:  the value from the ``data_folder`` parameter.
-        * ``ancillary_folder``:  the value from the ``ancillary_folder`` parameter.
-        * ``datastream``: the ``datastream`` as defined in the dataset configuration file.
-        * ``location_id``: the ``location_id`` as defined in the dataset configuration file.
-        * ``data_level``: the ``data_level`` as defined in the dataset configuration file.
+        * ``datastream``: the ``datastream`` as defined in the dataset config file.
+        * ``location_id``: the ``location_id`` as defined in the dataset config file.
+        * ``data_level``: the ``data_level`` as defined in the dataset config file.
         * ``year``: the year of the first timestamp in the file.
         * ``month``: the month of the first timestamp in the file.
         * ``day``: the day of the first timestamp in the file.
         * ``extension``: the file extension used by the output file writer.
+        """
 
-        Defaults to ``{storage_root}/{data_folder}/{datastream}.{extension}``.
+        data_filename_template: str = "{datastream}.{extension}"
+        """Template string to use for data filenames.
+        
+        Allows substitution of the following parameters using curly braces '{}':
+        
+        * ``ext``: the file extension from the storage data handler
+        * ``datastream`` from the dataset's global attributes
+        * ``location_id`` from the dataset's global attributes
+        * ``data_level`` from the dataset's global attributes
+        * Any other global attribute that has a string or integer data type.
         """
 
     parameters: Parameters = Field(default_factory=Parameters)  # type: ignore
     handler: ZarrHandler = Field(default_factory=ZarrHandler)
 
-    def fetch_data(self, start: datetime, end: datetime, datastream: str) -> xr.Dataset:
-        """-----------------------------------------------------------------------------
-        Fetches data for a given datastream between a specified time range.
-
-        Args:
-            start (datetime): The minimum datetime to fetch (inclusive).
-            end (datetime): The maximum datetime to fetch (exclusive).
-            datastream (str): The datastream id to search for.
-
-        Returns:
-            xr.Dataset: A dataset containing all the data in the storage area that spans
-            the specified datetimes.
-
-        -----------------------------------------------------------------------------"""
-        data_files = self._find_data(start=start, end=end, datastream=datastream)
-        full_dataset = self.handler.reader.read(data_files[0].as_posix())
-        dataset_in_range = full_dataset.sel(time=slice(start, end))
-        return dataset_in_range.compute()  # type: ignore
-
-    def _get_dataset_filepath(self, dataset: xr.Dataset) -> Path:
-        data_stub_path = Template(self.parameters.data_storage_path.as_posix())
-        extension = self.handler.writer.file_extension
-        extension = extension if not extension.startswith(".") else extension[1:]
-        datastream_dir = Path(
-            data_stub_path.substitute(
-                get_fields_from_dataset(dataset),
-                extension=extension,
-            )
-        )
-        return datastream_dir / f"{dataset.attrs['datastream']}.{extension}"
-
-    def _find_data(self, start: datetime, end: datetime, datastream: str) -> List[Path]:
-        unresolved = self.parameters.data_storage_path.as_posix()
-        extension = self.handler.writer.file_extension
-        extension = extension if not extension.startswith(".") else extension[1:]
-        semi_resolved = Template(unresolved).substitute(
-            get_fields_from_datastream(datastream),
-            allow_missing=True,
-            extension=extension,
-        )
-        root_path, pattern = self._extract_time_substitutions(semi_resolved, start, end)
-        pattern += f"{datastream}.{extension}"  # zarr folder for the datastream, not included by pattern
-        return list(root_path.glob(pattern))
-
-    def _extract_time_substitutions(
-        self, template_str: str, start: datetime, end: datetime
-    ) -> Tuple[Path, str]:
-        """Extracts the root path above unresolved time substitutions and provides a pattern to search below that."""
-        year = start.strftime("%Y") if start.year == end.year else "*"
-        month = (
-            start.strftime("%m") if year != "*" and start.month == end.month else "*"
-        )
-        resolved = Template(template_str).substitute(year=year, month=month, day="*")
-        if (split := resolved.find("*")) != -1:
-            return Path(resolved[:split]), resolved[split:]
-        return Path(resolved), ""
+    def _filter_between_dates(
+        self, filepaths: Iterable[Path], start: datetime, end: datetime
+    ) -> List[Path]:
+        # Zarr filenames don't include dates. There should also only be one filepath
+        # matching the data to fetch, so warn if otherwise
+        zarr_files = sorted(filepaths)
+        if len(zarr_files) > 1:
+            logger.warning("More than zarr file found: %s", zarr_files)
+        return zarr_files
 
 
 # HACK: Update forward refs to get around error I couldn't replicate with simpler code

--- a/tsdat/io/writers.py
+++ b/tsdat/io/writers.py
@@ -28,7 +28,8 @@ class NetCDFWriter(FileWriter):
     File compression is used by default to save disk space. To disable compression set the
     `compression_level` parameter to `0`.
 
-    ------------------------------------------------------------------------------------"""
+    ------------------------------------------------------------------------------------
+    """
 
     class Parameters(BaseModel, extra=Extra.forbid):
         compression_level: int = 1
@@ -41,7 +42,7 @@ class NetCDFWriter(FileWriter):
         """Keyword arguments passed directly to xr.Dataset.to_netcdf()."""
 
     parameters: Parameters = Parameters()
-    file_extension: str = ".nc"
+    file_extension: str = "nc"
 
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any
@@ -95,7 +96,8 @@ class SplitNetCDFWriter(NetCDFWriter):
     `Dataset.to_netcdf()` as keyword arguments. File compression is used by default to save
     disk space. To disable compression set the `compression_level` parameter to `0`.
 
-    ------------------------------------------------------------------------------------"""
+    ------------------------------------------------------------------------------------
+    """
 
     class Parameters(NetCDFWriter.Parameters):
         time_interval: int = 1
@@ -105,7 +107,7 @@ class SplitNetCDFWriter(NetCDFWriter):
         """Time interval unit."""
 
     parameters: Parameters = Parameters()
-    file_extension: str = ".nc"
+    file_extension: str = "nc"
 
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any
@@ -115,7 +117,6 @@ class SplitNetCDFWriter(NetCDFWriter):
         to_netcdf_kwargs["encoding"] = encoding_dict
 
         for variable_name in cast(Iterable[str], dataset.variables):
-
             # Prevent Xarray from setting 'nan' as the default _FillValue
             encoding_dict[variable_name] = dataset[variable_name].encoding  # type: ignore
             if (
@@ -171,7 +172,7 @@ class CSVWriter(FileWriter):
         to_csv_kwargs: Dict[str, Any] = {}
 
     parameters: Parameters = Parameters()
-    file_extension: str = ".csv"
+    file_extension: str = "csv"
 
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any
@@ -249,7 +250,7 @@ class ParquetWriter(FileWriter):
         to_parquet_kwargs: Dict[str, Any] = {}
 
     parameters: Parameters = Parameters()
-    file_extension: str = ".parquet"
+    file_extension: str = "parquet"
 
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any
@@ -274,7 +275,7 @@ class ZarrWriter(FileWriter):
         to_zarr_kwargs: Dict[str, Any] = {}
 
     parameters: Parameters = Parameters()
-    file_extension: str = ".zarr"
+    file_extension: str = "zarr"
 
     def write(
         self, dataset: xr.Dataset, filepath: Optional[Path] = None, **kwargs: Any

--- a/tsdat/io/writers.py
+++ b/tsdat/io/writers.py
@@ -5,7 +5,7 @@ import pandas as pd
 import xarray as xr
 from typing import Any, Dict, Iterable, List, Optional, cast, Hashable
 from pathlib import Path
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field
 from .base import FileWriter
 from ..utils import get_filename
 
@@ -41,7 +41,7 @@ class NetCDFWriter(FileWriter):
         to_netcdf_kwargs: Dict[str, Any] = {}
         """Keyword arguments passed directly to xr.Dataset.to_netcdf()."""
 
-    parameters: Parameters = Parameters()
+    parameters: Parameters = Field(default_factory=Parameters)
     file_extension: str = "nc"
 
     def write(
@@ -106,7 +106,7 @@ class SplitNetCDFWriter(NetCDFWriter):
         time_unit: str = "D"
         """Time interval unit."""
 
-    parameters: Parameters = Parameters()
+    parameters: Parameters = Field(default_factory=Parameters)
     file_extension: str = "nc"
 
     def write(
@@ -171,7 +171,7 @@ class CSVWriter(FileWriter):
         dim_order: Optional[List[str]] = None
         to_csv_kwargs: Dict[str, Any] = {}
 
-    parameters: Parameters = Parameters()
+    parameters: Parameters = Field(default_factory=Parameters)
     file_extension: str = "csv"
 
     def write(
@@ -249,7 +249,7 @@ class ParquetWriter(FileWriter):
         dim_order: Optional[List[str]] = None
         to_parquet_kwargs: Dict[str, Any] = {}
 
-    parameters: Parameters = Parameters()
+    parameters: Parameters = Field(default_factory=Parameters)
     file_extension: str = "parquet"
 
     def write(
@@ -274,7 +274,7 @@ class ZarrWriter(FileWriter):
     class Parameters(BaseModel, extra=Extra.forbid):
         to_zarr_kwargs: Dict[str, Any] = {}
 
-    parameters: Parameters = Parameters()
+    parameters: Parameters = Field(default_factory=Parameters)
     file_extension: str = "zarr"
 
     def write(
@@ -290,4 +290,8 @@ class ZarrWriter(FileWriter):
             ):
                 encoding_dict[variable_name]["_FillValue"] = None
 
-        dataset.to_zarr(filepath, encoding=encoding_dict, **self.parameters.to_zarr_kwargs)  # type: ignore
+        dataset.to_zarr(
+            filepath,
+            encoding=encoding_dict,
+            **self.parameters.to_zarr_kwargs,
+        )  # type: ignore

--- a/tsdat/qc/base.py
+++ b/tsdat/qc/base.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 import numpy as np
 from pydantic import BaseModel, Extra
 import xarray as xr
@@ -16,7 +16,9 @@ class QualityChecker(ParameterizedClass, ABC):
     ---------------------------------------------------------------------------------"""
 
     @abstractmethod
-    def run(self, dataset: xr.Dataset, variable_name: str) -> NDArray[np.bool_]:
+    def run(
+        self, dataset: xr.Dataset, variable_name: str
+    ) -> Union[NDArray[np.bool_], None]:
         """-----------------------------------------------------------------------------
         Identifies and flags quality problems with the data.
 
@@ -108,6 +110,8 @@ class QualityManager(BaseModel, extra=Extra.forbid):
         variables = self._get_variables_to_run(dataset)
         for variable_name in variables:
             issues = self.checker.run(dataset, variable_name)
+            if issues is None:
+                continue
             for handler in self.handlers:
                 dataset = handler.run(dataset, variable_name, issues)
         return dataset

--- a/tsdat/transform/converters.py
+++ b/tsdat/transform/converters.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Literal, Optional, Tuple
 
@@ -73,7 +74,7 @@ class CreateTimeGrid(DataConverter):
         dataset_config: Optional["DatasetConfig"] = None,
         retrieved_dataset: Optional[RetrievedDataset] = None,
         retriever: Optional["StorageRetriever"] = None,
-        time_span: Optional[Tuple[str, str]] = None,
+        time_span: Optional[Tuple[datetime, datetime]] = None,
         input_key: Optional[str] = None,
         **kwargs: Any,
     ) -> Optional[xr.DataArray]:
@@ -82,8 +83,7 @@ class CreateTimeGrid(DataConverter):
 
         # TODO: if not time_span, then get the time range from the retrieved data
 
-        start = pd.to_datetime(time_span[0], format="%Y%m%d.%H%M%S")  # type: ignore
-        end = pd.to_datetime(time_span[1], format="%Y%m%d.%H%M%S")  # type: ignore
+        start, end = time_span[0], time_span[1]
         time_deltas = pd.timedelta_range(
             start="0 days",
             end=end - start,
@@ -118,7 +118,6 @@ class CreateTimeGrid(DataConverter):
 
 
 class _ADIBaseTransformer(DataConverter):
-
     transformation_type: str
     coord: str = "ALL"
 

--- a/tsdat/transform/converters.py
+++ b/tsdat/transform/converters.py
@@ -8,10 +8,10 @@ import xarray as xr
 
 from ..io.base import DataConverter, RetrievedDataset
 
-if TYPE_CHECKING:
-    # Prevent any chance of runtime circular imports for typing-only imports
-    from ..config.dataset import DatasetConfig
-    from ..io.retrievers import StorageRetriever
+# Prevent any chance of runtime circular imports for typing-only imports
+if TYPE_CHECKING:  # pragma: no cover
+    from ..config.dataset import DatasetConfig  # pragma: no cover
+    from ..io.retrievers import StorageRetriever  # pragma: no cover
 
 __all__ = [
     "CreateTimeGrid",

--- a/tsdat/utils.py
+++ b/tsdat/utils.py
@@ -276,8 +276,7 @@ def get_filename(
         str: The filename constructed from provided parameters.
 
     ---------------------------------------------------------------------------------"""
-    if extension.startswith("."):
-        extension = extension[1:]
+    extension = extension.lstrip(".")
 
     start_date, start_time = get_start_date_and_time_str(dataset)
     return FILENAME_TEMPLATE.substitute(
@@ -293,24 +292,6 @@ def get_fields_from_dataset(dataset: xr.Dataset) -> dict[str, Any]:
     return {
         **dict(dataset.attrs),
         **datetime_substitutions(dataset.time.values[0]),
-    }
-
-
-def get_fields_from_datastream(datastream: str) -> Dict[str, Optional[str]]:
-    # assumes datastream = loc.name[-qual][-temp].lvl
-    ds_parts = datastream.split(".")
-    assert len(ds_parts) == 3
-
-    name_qual_temp = ds_parts[1].split("-")
-    assert len(name_qual_temp) <= 3
-
-    return {
-        "datastream": datastream,
-        "location_id": ds_parts[0],
-        "dataset_name": name_qual_temp[0],
-        "qualifier": name_qual_temp[1] if len(name_qual_temp) >= 2 else None,
-        "temporal": name_qual_temp[2] if len(name_qual_temp) == 3 else None,
-        "data_level": ds_parts[2],
     }
 
 

--- a/tsdat/utils.py
+++ b/tsdat/utils.py
@@ -1,14 +1,14 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 import typer
 import xarray as xr
 from numpy.typing import NDArray
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field
 from tsdat.tstring import Template
 
 
@@ -66,7 +66,7 @@ class ParameterizedClass(BaseModel, extra=Extra.forbid):
     ------------------------------------------------------------------------------------
     """
 
-    parameters: Any = {}
+    parameters: Any = Field(default_factory=dict)
 
 
 def _nested_union(dict1: Dict[Any, Any], dict2: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/tsdat/utils.py
+++ b/tsdat/utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -11,6 +12,7 @@ from numpy.typing import NDArray
 from pydantic import BaseModel, Extra, Field
 from tsdat.tstring import Template
 
+import logging
 
 __all__ = [
     "ParameterizedClass",
@@ -25,6 +27,8 @@ __all__ = [
     "FILENAME_TEMPLATE",
     "generate_schema",
 ]
+
+logger = logging.getLogger(__name__)
 
 DATASTREAM_TEMPLATE = Template(
     "{location_id}.{dataset_name}[-{qualifier}][-{temporal}].{data_level}"
@@ -245,6 +249,14 @@ def get_start_date_and_time_str(dataset: xr.Dataset) -> Tuple[str, str]:
     ---------------------------------------------------------------------------------"""
     timestamp = get_start_time(dataset)
     return timestamp.strftime("%Y%m%d"), timestamp.strftime("%H%M%S")
+
+
+def get_file_datetime_str(file: Path | str) -> str:
+    datetime_match = re.match(r".*(\d{8}\.\d{6}).*", Path(file).name)
+    if datetime_match is not None:
+        return datetime_match.groups()[0]
+    logger.error(f"File {file} does not contain a recognized date string")
+    return ""
 
 
 def get_datastream(**global_attrs: str) -> str:

--- a/tsdat/utils.py
+++ b/tsdat/utils.py
@@ -23,6 +23,7 @@ __all__ = [
     "get_start_date_and_time_str",
     "get_filename",
     "get_datastream",
+    "get_fields_from_datastream",
     "DATASTREAM_TEMPLATE",
     "FILENAME_TEMPLATE",
     "generate_schema",
@@ -261,6 +262,17 @@ def get_file_datetime_str(file: Path | str) -> str:
 
 def get_datastream(**global_attrs: str) -> str:
     return DATASTREAM_TEMPLATE.substitute(global_attrs)
+
+
+def get_fields_from_datastream(datastream: str) -> Dict[str, str]:
+    """Extracts fields from the datastream.
+
+    WARNING: this only works for the default datastream template.
+    """
+    fields = DATASTREAM_TEMPLATE.extract_substitutions(datastream)
+    if fields is None:
+        return {}
+    return {k: v for k, v in fields.items() if v is not None}
 
 
 def get_filename(


### PR DESCRIPTION
Semi-large refactor of the storage classes to better support custom storage paths and naming conventions.

Previously the FileSystem storage class assumed that files would be named like `datastream.start.end.ext`, where `datastream` was always `location.name-qual-temp.level`, but also allowed users to provide their own `datastream` as a global attribute which could be used instead. If a custom `datastream` was set (such as those used by A2e), the `FileSystem` storage classes would try and fail to parse out the location, name, qualifier, temporal, and data level attributes from the datastream, causing the whole pipeline to crash.

Now, an optional metadata dictionary can be passed to various methods that previously relied on parsing fields from the `datastream`. This means we can use storage paths like `"data/{location_id}/{datastream}"` and can even things like `"data/{location_id}/{z_id}/{datastream}"` while still supporting data storage and retrieval.


TODO:

- [x] Add tests for new features
- [x] Add documentation for new features