### PR TITLE
Ancillary filepath

### DIFF
--- a/docs/source/config/hook_functions.rst
+++ b/docs/source/config/hook_functions.rst
@@ -33,20 +33,10 @@ output. Below is shown a custom plotting example:
 
         date, time = get_start_date_and_time_str(dataset)
 
-        with self.storage.uploadable_dir() as tmp_dir:
-
-            fig, ax = plt.subplots()
-            dataset["example_var"].plot(ax=ax, x="time")  # type: ignore
-            fig.suptitle(f"Example Variable at {location} on {date} {time}")
-            format_time_xticks(ax)
-            plot_filepath = self.storage.get_ancillary_filepath(
-                title="example_plot",
-                extension="png",
-                root_dir=tmp_dir,
-                dataset=dataset,
-            )
-            fig.savefig(plot_filepath)
-            plt.close(fig)
+        fig, ax = plt.subplots()
+        dataset["example_var"].plot(ax=ax, x="time")  # type: ignore
+        fig.savefig(self.get_ancillary_filepath(title="example_plot"))
+        plt.close(fig)
 
 
 .. autoclass:: tsdat.pipeline.pipelines.IngestPipeline

--- a/docs/source/tutorials/data_ingest.rst
+++ b/docs/source/tutorials/data_ingest.rst
@@ -750,38 +750,24 @@ desired:
 
           date, time = get_start_date_and_time_str(dataset)
 
-          plt.style.use("default")  # clear any styles that were set before
-          plt.style.use("shared/styling.mplstyle")
-
-          with self.storage.uploadable_dir() as tmp_dir:
+          with plt.style.context("shared/styling.mplstyle")
 
             fig, ax = plt.subplots()
             dataset["temperature"].plot(ax=ax, x="time", c=cmocean.cm.deep_r(0.5))
             fig.suptitle(f"Temperature measured at {location} on {date} {time}")
 
-            plot_file = self.storage.get_ancillary_filepath(
-                title="temperature",
-                extension="png",
-                root_dir=tmp_dir,
-                dataset=dataset,
-            )
+            plot_file = self.get_ancillary_filepath(title="temperature")
             fig.savefig(plot_file)
             plt.close(fig)
 
             # Create plot display using act
-            variable = "wave_height"
             display = act.plotting.TimeSeriesDisplay(
                 dataset, figsize=(15, 10), subplot_shape=(2,)
             )
-            display.plot(variable, subplot_index=(0,), label="Wave Height")  # data in top plot
-            display.qc_flag_block_plot(variable, subplot_index=(1,)) # qc in bottom plot
+            display.plot("wave_height", subplot_index=(0,), label="Wave Height")  # data in top plot
+            display.qc_flag_block_plot("wave_height", subplot_index=(1,)) # qc in bottom plot
 
-            plot_file = self.storage.get_ancillary_filepath(
-                title=variable,
-                extension="png",
-                root_dir=tmp_dir,
-                dataset=dataset,
-            )
+            plot_file = self.get_ancillary_filepath(title="wave_height")
             display.fig.savefig(plot_file)
             plt.close(display.fig)
 

--- a/test/config/test_pipeline_config.py
+++ b/test/config/test_pipeline_config.py
@@ -2,11 +2,12 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any, Dict
-from tsdat.config.pipeline import PipelineConfig
+
 from tsdat.config.dataset import DatasetConfig
+from tsdat.config.pipeline import PipelineConfig
+from tsdat.config.quality import QualityConfig
 from tsdat.config.retriever import RetrieverConfig
 from tsdat.config.storage import StorageConfig
-from tsdat.config.quality import QualityConfig
 from tsdat.utils import model_to_dict
 
 
@@ -24,7 +25,7 @@ def test_pipeline_config_merges_overrides():
     quality.managers[0].exclude = []
 
     expected_dict: Dict[str, Any] = {
-        "classname": "tsdat.pipeline.pipelines.IngestPipeline",
+        "classname": "test.pipeline.examples.Ingest",
         "parameters": {},
         "triggers": [re.compile(r".*\.csv")],
         "retriever": model_to_dict(retriever),

--- a/test/config/yaml/pipeline.yaml
+++ b/test/config/yaml/pipeline.yaml
@@ -1,4 +1,4 @@
-classname: tsdat.pipeline.pipelines.IngestPipeline
+classname: test.pipeline.examples.Ingest
 
 triggers:
   - '.*\.csv'

--- a/test/pipeline/examples.py
+++ b/test/pipeline/examples.py
@@ -1,0 +1,12 @@
+import xarray as xr
+from matplotlib import pyplot as plt
+
+import tsdat
+
+
+class Ingest(tsdat.IngestPipeline):
+    def hook_plot_dataset(self, dataset: xr.Dataset):
+        fig, ax = plt.subplots()
+        ax.plot([1, 2], [3, 4])
+        filepath = self.get_ancillary_filepath("example")
+        fig.savefig(filepath)

--- a/test/pipeline/test_pipeline.py
+++ b/test/pipeline/test_pipeline.py
@@ -58,6 +58,7 @@ def test_ingest_pipeline():
     save_path = Path(
         "storage/root/data/sgp.example.b1/sgp.example.b1.20220324.214300.nc"
     )
+    assert save_path.exists()
     saved_dataset: xr.Dataset = xr.open_dataset(save_path)  # type: ignore
     assert_close(saved_dataset, expected)
     assert saved_dataset.attrs["code_version"]
@@ -66,6 +67,12 @@ def test_ingest_pipeline():
         saved_dataset["first"].encoding.get("_FillValue", None) == -9999
         or saved_dataset["first"].attrs.get("_FillValue", None) == -9999
     )
+
+    # Plot file saved to disk
+    plot_path = Path(
+        "storage/root/ancillary/sgp/sgp.example.b1/sgp.example.b1.20220324.214300.example.png"
+    )
+    assert plot_path.exists()
 
 
 @pytest.mark.requires_adi


### PR DESCRIPTION
This PR adds a `IngestPipeline.get_ancillary_filepath` convenience function that wraps the `IngestPipeline.storage.get_ancillary_filepath` function, providing all the default arguments except for the title.


Now this is valid:

```python
# in user's IngestPipeline class

# plotting code ...
filepath = self.get_ancillary_filepath("wind_speed")
fig.savefig(filepath)
```

Previously this was necessary:

```python
# in user's IngestPipeline class

with self.storage.uploadable_dir() as tmp_dir:
    # plotting code ...
    filepath = self.get_ancillary_filepath(title="wind_speed", dataset=dataset, root_dir=tmp_dir)
    fig.savefig(filepath)
```

Closes #147 