### PR TITLE
Fix encoding for string data

### DIFF
--- a/tsdat/io/writers.py
+++ b/tsdat/io/writers.py
@@ -68,17 +68,17 @@ class NetCDFWriter(FileWriter):
             ):
                 encoding_dict[variable_name]["_FillValue"] = None
 
-            if self.parameters.compression_level:
-                # Handle str dtypes: https://github.com/pydata/xarray/issues/2040
-                if dataset[variable_name].dtype.kind == "U":
-                    encoding_dict[variable_name]["dtype"] = "S1"
-
+            if self.parameters.compression_level and dataset[variable_name].dtype.kind != "U":
                 encoding_dict[variable_name].update(
                     {
                         self.parameters.compression_engine: True,
                         "complevel": self.parameters.compression_level,
                     }
                 )
+
+        # Handle str dtypes: https://github.com/pydata/xarray/issues/2040
+        if dataset[variable_name].dtype.kind == "U":
+            encoding_dict[variable_name]["dtype"] = "str"
 
         if "time" in dataset.dims:
             to_netcdf_kwargs["unlimited_dims"] = set(


### PR DESCRIPTION
Using `"str"` instead of "S1" for the datatype fixes the `string1` dimension problem for string variables. Also removed compression encoding for string variables to fix `NetCDF: Filter error: bad id or parameters or duplicate filter` error, which was a regression from NetCDF4 1.5.8. 