### PR TITLE
Improve logging for warnings

### DIFF
--- a/test/io/test_data_handlers.py
+++ b/test/io/test_data_handlers.py
@@ -155,7 +155,7 @@ def test_zip_reader(sample_dataset: xr.Dataset):
 
 def test_netcdf_writer(sample_dataset: xr.Dataset):
     expected = sample_dataset.copy(deep=True)  # type: ignore
-    writer = NetCDFWriter()
+    writer = NetCDFWriter(file_extension=".nc")
     tmp_dir = tempfile.TemporaryDirectory()
 
     tmp_file = Path(tmp_dir.name) / "test_writer.nc"

--- a/tsdat/config/attributes.py
+++ b/tsdat/config/attributes.py
@@ -1,4 +1,4 @@
-import warnings
+import logging
 from typing import Any, Dict, Optional
 
 from pydantic import (
@@ -14,6 +14,8 @@ from pydantic.fields import ModelField
 
 from ..utils import get_datastream
 from .utils import get_code_version
+
+logger = logging.getLogger(__name__)
 
 
 class AttributeModel(BaseModel, extra=Extra.allow):
@@ -182,7 +184,7 @@ class GlobalAttributes(AttributeModel):
     @classmethod
     def warn_if_dynamic_properties_are_set(cls, v: str, field: ModelField) -> str:
         if v:
-            warnings.warn(
+            logger.warning(
                 f"The '{field.name}' attribute should not be set explicitly. The"
                 f" current value of '{v}' will be ignored."
             )

--- a/tsdat/config/variables.py
+++ b/tsdat/config/variables.py
@@ -1,4 +1,4 @@
-import warnings
+import logging
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -13,6 +13,8 @@ from pydantic import (
 )
 
 from .attributes import AttributeModel
+
+logger = logging.getLogger(__name__)
 
 ureg = UnitRegistry()
 ureg.define("unitless = count = 1")  # type: ignore
@@ -33,68 +35,95 @@ class VariableAttributes(AttributeModel):
     (e.g., valid_*, fail_*, and warn_* properties)."""
 
     units: Optional[str] = Field(
-        description="A string indicating the units the data are measured in. Tsdat uses"
-        " pint to handle unit conversions, so this string must be compatible with the"
-        " pint list of units, if provided. A complete list of compatible units can be"
-        " found here: https://github.com/hgrecco/pint/blob/master/pint/default_en.txt."
-        " If the property is unitless, then the string '1' should be used. If the units"
-        " of the property are not known, then the units attribute should be omitted and"
-        " the comment attribute should include a note indicating that units are not"
-        " known. Doing so provides helpful context for data users."
+        description=(
+            "A string indicating the units the data are measured in. Tsdat uses pint to"
+            " handle unit conversions, so this string must be compatible with the pint"
+            " list of units, if provided. A complete list of compatible units can be"
+            " found here:"
+            " https://github.com/hgrecco/pint/blob/master/pint/default_en.txt. If the"
+            " property is unitless, then the string '1' should be used. If the units of"
+            " the property are not known, then the units attribute should be omitted"
+            " and the comment attribute should include a note indicating that units are"
+            " not known. Doing so provides helpful context for data users."
+        )
     )
     long_name: Optional[StrictStr] = Field(
         default=None,
-        description="A brief label for the name of the measured property. The xarray"
-        " python library automatically searches for this attribute to use as an axes"
-        " label in plots, so the value should be suitable for display.",
+        description=(
+            "A brief label for the name of the measured property. The xarray python"
+            " library automatically searches for this attribute to use as an axes label"
+            " in plots, so the value should be suitable for display."
+        ),
     )
     standard_name: Optional[StrictStr] = Field(
         default=None,
-        description="A string exactly matching a value in the CF Standard Name table"
-        " which is used to provide a standardized way of identifying variables and"
-        " measurements across heterogeneous datasets and domains. If a suitable match"
-        " does not exist, then this attribute should be omitted. The full list of CF"
-        " Standard Names is at: https://cfconventions.org/Data/cf-standard-names.",
+        description=(
+            "A string exactly matching a value in the CF Standard Name table which is"
+            " used to provide a standardized way of identifying variables and"
+            " measurements across heterogeneous datasets and domains. If a suitable"
+            " match does not exist, then this attribute should be omitted. The full"
+            " list of CF Standard Names is at:"
+            " https://cfconventions.org/Data/cf-standard-names."
+        ),
     )
     coverage_content_type: Optional[str] = Field(
         default=None,
-        description="An ISO 19115-1 code to indicate the source of the data (image, "
-        "thematicClassification, physicalMeasurement, auxiliaryInformation, "
-        "qualityInformation, referenceInformation, modelResult, or coordinate).",
+        description=(
+            "An ISO 19115-1 code to indicate the source of the data (image, "
+            "thematicClassification, physicalMeasurement, auxiliaryInformation, "
+            "qualityInformation, referenceInformation, modelResult, or coordinate)."
+        ),
     )
     cf_role: Optional[str] = Field(
         title="CF Role",
         default=None,
-        description="Allowed values are defined in Chapter 9.5 CF guidelines and consist of: timeseries_id, profile_id, "
-        "and trajectory_id, depending on the featureType represented in the dataset, as specified by the featureType "
-        "global attribute.",
+        description=(
+            "Allowed values are defined in Chapter 9.5 CF guidelines and consist of:"
+            " timeseries_id, profile_id, and trajectory_id, depending on the"
+            " featureType represented in the dataset, as specified by the featureType"
+            " global attribute."
+        ),
     )
     accuracy: Optional[float] = Field(
         default=None,
-        description="The sensor accuracy is the closeness of the measurements to the variable's true value. It should be"
-        " given in the same units as the measured variable. If the instrument has been calibrated multiple times with "
-        "different results, the most recent accuracy should be provided here "
-        "(see instrument_variable:calibration_date).",
+        description=(
+            "The sensor accuracy is the closeness of the measurements to the variable's"
+            " true value. It should be given in the same units as the measured"
+            " variable. If the instrument has been calibrated multiple times with"
+            " different results, the most recent accuracy should be provided here (see"
+            " instrument_variable:calibration_date)."
+        ),
     )
     precision: Optional[float] = Field(
         default=None,
-        description="The sensor precision is the closeness of the measurements to each other. It should be given in the "
-        "same units as the measured variable. If the instrument has been calibrated multiple times with different "
-        "results, the most recent precision should be provided here (see instrument_variable:calibration_date).",
+        description=(
+            "The sensor precision is the closeness of the measurements to each other."
+            " It should be given in the same units as the measured variable. If the"
+            " instrument has been calibrated multiple times with different results, the"
+            " most recent precision should be provided here (see"
+            " instrument_variable:calibration_date)."
+        ),
     )
     resolution: Optional[float] = Field(
         default=None,
-        description="The sensor resolution is the smallest change it can represent in the quantity that it is measuring."
-        " It should be given in the same units as the measured variable.",
+        description=(
+            "The sensor resolution is the smallest change it can represent in the"
+            " quantity that it is measuring. It should be given in the same units as"
+            " the measured variable."
+        ),
     )
     instrument: Optional[str] = Field(
         default=None,
-        description="Variable attribute to be specified on each geophysical variable to identify the instrument that "
-        "collected the data. The value of the attribute should be set to another variable which contains the details of"
-        " the instrument. There can be multiple instruments involved depending on if all the instances of the "
-        "featureType in the collection come from the same instrument or not. If multiple instruments are involved, a "
-        "variable should be defined for each instrument and referenced from the geophysical variable in a comma "
-        "separated string.",
+        description=(
+            "Variable attribute to be specified on each geophysical variable to"
+            " identify the instrument that collected the data. The value of the"
+            " attribute should be set to another variable which contains the details of"
+            " the instrument. There can be multiple instruments involved depending on"
+            " if all the instances of the featureType in the collection come from the"
+            " same instrument or not. If multiple instruments are involved, a variable"
+            " should be defined for each instrument and referenced from the geophysical"
+            " variable in a comma separated string."
+        ),
     )
     make_model: Optional[str] = Field(
         title="Make and Model",
@@ -103,77 +132,97 @@ class VariableAttributes(AttributeModel):
     )
     calibration_date: Optional[str] = Field(
         default=None,
-        description="The date the instrument was last calibrated. Value should be specified using ISO-8601 compatible "
-        "strings.",
+        description=(
+            "The date the instrument was last calibrated. Value should be specified"
+            " using ISO-8601 compatible strings."
+        ),
     )
     comment: Optional[StrictStr] = Field(
         default=None,
-        description="A user-friendly description of what the variable represents, how"
-        " it was measured or derived, or any other relevant information that increases"
-        " the ability of users to understand and use this data. This field plays a"
-        " considerable role in creating self-documenting data, so we highly recommend"
-        " including this field, especially for any variables which are particularly"
-        " important for your dataset. Additionally, if the units for an attribute are"
-        " unknown, then this field must include the phrase: 'Unknown units.' so that"
-        " users know there is some uncertainty around this property. Variables that are"
-        " unitless (e.g., categorical data or ratios), should set the 'units' to '1'.",
+        description=(
+            "A user-friendly description of what the variable represents, how it was"
+            " measured or derived, or any other relevant information that increases the"
+            " ability of users to understand and use this data. This field plays a"
+            " considerable role in creating self-documenting data, so we highly"
+            " recommend including this field, especially for any variables which are"
+            " particularly important for your dataset. Additionally, if the units for"
+            " an attribute are unknown, then this field must include the phrase:"
+            " 'Unknown units.' so that users know there is some uncertainty around this"
+            " property. Variables that are unitless (e.g., categorical data or ratios),"
+            " should set the 'units' to '1'."
+        ),
     )
     valid_range: Optional[List[float]] = Field(
         default=None,
         min_items=2,
         max_items=2,
-        description="A two-element list of [min, max] values outside of which the data"
-        " should be treated as missing. If applying QC tests, then users should"
-        " configure the quality managers to flag values outside of this range as having"
-        " a 'Bad' assessment and replace those values with the variable's _FillValue.",
+        description=(
+            "A two-element list of [min, max] values outside of which the data should"
+            " be treated as missing. If applying QC tests, then users should configure"
+            " the quality managers to flag values outside of this range as having a"
+            " 'Bad' assessment and replace those values with the variable's _FillValue."
+        ),
     )
     fail_range: Optional[List[float]] = Field(
         default=None,
         min_items=2,
         max_items=2,
-        description="A two-element list of [min, max] values outside of which the data"
-        " should be teated with heavy skepticism as missing. If applying QC tests, then"
-        " users should configure the quality managers to flag values outside of this"
-        " range as having a 'Bad' assessment.",
+        description=(
+            "A two-element list of [min, max] values outside of which the data should"
+            " be teated with heavy skepticism as missing. If applying QC tests, then"
+            " users should configure the quality managers to flag values outside of"
+            " this range as having a 'Bad' assessment."
+        ),
     )
     warn_range: Optional[List[float]] = Field(
         default=None,
         min_items=2,
         max_items=2,
-        description="A two-element list of [min, max] values outside of which the data"
-        " should be teated with some skepticism as missing. If applying QC tests, then"
-        " users should configure the quality managers to flag values outside of this"
-        " range as having an 'Indeterminate' assessment.",
+        description=(
+            "A two-element list of [min, max] values outside of which the data should"
+            " be teated with some skepticism as missing. If applying QC tests, then"
+            " users should configure the quality managers to flag values outside of"
+            " this range as having an 'Indeterminate' assessment."
+        ),
     )
     valid_delta: Optional[float] = Field(
         default=None,
-        description="The largest difference between consecutive values in the data"
-        " outside of which the data should be treated as missing. If applying QC tests,"
-        " then users should configure the quality managers to flag values outside of"
-        " this range as having a 'Bad' assessment and replace those values with the"
-        " variable's _FillValue.",
+        description=(
+            "The largest difference between consecutive values in the data outside of"
+            " which the data should be treated as missing. If applying QC tests, then"
+            " users should configure the quality managers to flag values outside of"
+            " this range as having a 'Bad' assessment and replace those values with the"
+            " variable's _FillValue."
+        ),
     )
     fail_delta: Optional[float] = Field(
         default=None,
-        description="The largest difference between consecutive values in the data"
-        " outside of which the data should be teated with heavy skepticism as missing."
-        " If applying QC tests, then users should configure the quality managers to"
-        " flag values outside of this range as having a 'Bad' assessment.",
+        description=(
+            "The largest difference between consecutive values in the data outside of"
+            " which the data should be teated with heavy skepticism as missing. If"
+            " applying QC tests, then users should configure the quality managers to"
+            " flag values outside of this range as having a 'Bad' assessment."
+        ),
     )
     warn_delta: Optional[float] = Field(
         default=None,
-        description="The largest difference between consecutive values in the data"
-        " outside of which the data should be teated with some skepticism as missing."
-        " If applying QC tests, then users should configure the quality managers to"
-        " flag values outside of this range as having an 'Indeterminate' assessment.",
+        description=(
+            "The largest difference between consecutive values in the data outside of"
+            " which the data should be teated with some skepticism as missing. If"
+            " applying QC tests, then users should configure the quality managers to"
+            " flag values outside of this range as having an 'Indeterminate'"
+            " assessment."
+        ),
     )
     fill_value: Optional[Any] = Field(
         default=None,
         alias="_FillValue",
-        description="A value used to initialize the variable's data and indicate that"
-        " the data is missing. Defaults to -9999 for numerical data. If choosing a"
-        " different value, it is important to use a value that could not reasonably be"
-        " mistaken for a physical value or data point.",
+        description=(
+            "A value used to initialize the variable's data and indicate that the data"
+            " is missing. Defaults to -9999 for numerical data. If choosing a different"
+            " value, it is important to use a value that could not reasonably be"
+            " mistaken for a physical value or data point."
+        ),
     )
 
     @validator("units")
@@ -185,7 +234,7 @@ class VariableAttributes(AttributeModel):
         try:
             ureg(unit_str)
         except PintError:
-            warnings.warn(
+            logger.warning(
                 f"'{unit_str}' is not a valid unit or combination of units. The string"
                 " will be kept as-is."
             )
@@ -212,31 +261,39 @@ class Variable(BaseModel, extra=Extra.forbid):
     coords pydantic model upon instantiation."""
 
     data: Optional[Any] = Field(
-        description="If the variable is not meant to be retrieved from an input dataset"
-        " and the value is known in advance, then the 'data' property should specify"
-        " its value exactly as it should appear in the output dataset. This is commonly"
-        " used for latitude/longitude/altitude data for datasets measured from a"
-        " specific geographical location."
+        description=(
+            "If the variable is not meant to be retrieved from an input dataset and the"
+            " value is known in advance, then the 'data' property should specify its"
+            " value exactly as it should appear in the output dataset. This is commonly"
+            " used for latitude/longitude/altitude data for datasets measured from a"
+            " specific geographical location."
+        )
     )
     dtype: StrictStr = Field(
-        description="The numpy dtype of the underlying data. This is passed to numpy as"
-        " the 'dtype' keyword argument used to initialize an array (e.g.,"
-        " `numpy.array([1.0, 2.0], dtype='float')`). Commonly-used values include"
-        " 'float', 'int', 'long'."
+        description=(
+            "The numpy dtype of the underlying data. This is passed to numpy as"
+            " the 'dtype' keyword argument used to initialize an array (e.g.,"
+            " `numpy.array([1.0, 2.0], dtype='float')`). Commonly-used values include"
+            " 'float', 'int', 'long'."
+        )
     )
     dims: List[StrictStr] = Field(
         unique_items=True,
-        description="A list of coordinate variable names that dimension this data"
-        " variable. Most commonly this will be set to ['time'], but for datasets where"
-        " there are multiple dimensions (e.g., ADCP data measuring current velocities"
-        " across time and several depths, it may look like ['time', 'depth']).",
+        description=(
+            "A list of coordinate variable names that dimension this data variable."
+            " Most commonly this will be set to ['time'], but for datasets where there"
+            " are multiple dimensions (e.g., ADCP data measuring current velocities"
+            " across time and several depths, it may look like ['time', 'depth'])."
+        ),
     )
     attrs: VariableAttributes = Field(
-        description="The attrs section is where variable-specific metadata are stored."
-        " This metadata is incredibly important for data users, and we recommend"
-        " including several properties for each variable in order to have the greatest"
-        " impact. In particular, we recommend adding the 'units', 'long_name', and"
-        " 'standard_name' attributes, if possible."
+        description=(
+            "The attrs section is where variable-specific metadata are stored. This"
+            " metadata is incredibly important for data users, and we recommend"
+            " including several properties for each variable in order to have the"
+            " greatest impact. In particular, we recommend adding the 'units',"
+            " 'long_name', and 'standard_name' attributes, if possible."
+        )
     )
     # @validator("name")
     # @classmethod

--- a/tsdat/io/base.py
+++ b/tsdat/io/base.py
@@ -402,7 +402,6 @@ class Storage(ParameterizedClass, ABC):
         Returns:
             datetime: The datetime of the last modification.
         """
-        return None
 
     def modified_since(
         self, datastream: str, last_modified: datetime

--- a/tsdat/io/writers.py
+++ b/tsdat/io/writers.py
@@ -1,14 +1,15 @@
 import copy
-import warnings
+import logging
+from pathlib import Path
+from typing import Any, Dict, Hashable, Iterable, List, Optional, cast
+
 import numpy as np
 import pandas as pd
 import xarray as xr
-from typing import Any, Dict, Iterable, List, Optional, cast, Hashable
-from pathlib import Path
 from pydantic import BaseModel, Extra, Field
-from .base import FileWriter
-from ..utils import get_filename
 
+from ..utils import get_filename
+from .base import FileWriter
 
 __all__ = [
     "NetCDFWriter",
@@ -17,6 +18,8 @@ __all__ = [
     "ParquetWriter",
     "ZarrWriter",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class NetCDFWriter(FileWriter):
@@ -205,7 +208,7 @@ class CSVWriter(FileWriter):
             elif len(shp) == 2:
                 d2.append(var)
             else:
-                warnings.warn(
+                logger.warning(
                     "CSV writer cannot save variables with more than 2 dimensions."
                 )
 

--- a/tsdat/qc/handlers.py
+++ b/tsdat/qc/handlers.py
@@ -1,4 +1,4 @@
-import warnings
+import logging
 from typing import Any, Dict, List, Literal, Optional, Union
 
 import numpy as np
@@ -16,6 +16,9 @@ __all__ = [
     "RemoveFailedValues",
     "SortDatasetByCoordinate",
 ]
+
+
+logger = logging.getLogger(__name__)
 
 
 class DataQualityError(ValueError):
@@ -123,10 +126,7 @@ class RecordQualityResults(QualityHandler):
         @root_validator(pre=True)
         def deprecate_bit_parameter(cls, values: Dict[str, Any]) -> Dict[str, Any]:
             if "bit" in values:
-                warnings.warn(
-                    "The 'bit' argument is deprecated, please remove it.",
-                    category=DeprecationWarning,
-                )
+                logger.warning("The 'bit' argument is deprecated, please remove it.")
             return values
 
         @validator("assessment", pre=True)

--- a/tsdat/transform/adi.py
+++ b/tsdat/transform/adi.py
@@ -1,11 +1,13 @@
+import logging
 import math
 import re
 from typing import Any, Dict, List
-import warnings
 
+import numpy as np
 import xarray as xr
 from xarray.core.coordinates import DataArrayCoordinates
-import numpy as np
+
+logger = logging.getLogger(__name__)
 
 try:
     import cds3
@@ -16,7 +18,7 @@ try:
     CDSGroup = cds3.Group
     CDSVar = cds3.Var
 except ImportError:
-    warnings.warn(
+    logger.warning(
         "Warning: ADI libraries are not installed. Some time series transformation"
         " functions may not work."
     )
@@ -36,31 +38,69 @@ OUTPUT_DATASTREAM = "output_ds"
 INPUT_DATASTREAM = "input_ds"
 
 adi_qc_atts = {
-    "bit_1_description": "QC_BAD:  Transformation could not finish, value set to missing_value.",
+    "bit_1_description": (
+        "QC_BAD:  Transformation could not finish, value set to missing_value."
+    ),
     "bit_1_assessment": "Bad",
-    "bit_2_description": "QC_INDETERMINATE:  Some, or all, of the input values used to create this output value had a QC assessment of Indeterminate.",
+    "bit_2_description": (
+        "QC_INDETERMINATE:  Some, or all, of the input values used to create this"
+        " output value had a QC assessment of Indeterminate."
+    ),
     "bit_2_assessment": "Indeterminate",
-    "bit_3_description": "QC_INTERPOLATE:  Indicates a non-standard interpolation using points other than the two that bracket the target index was applied.",
+    "bit_3_description": (
+        "QC_INTERPOLATE:  Indicates a non-standard interpolation using points other"
+        " than the two that bracket the target index was applied."
+    ),
     "bit_3_assessment": "Indeterminate",
-    "bit_4_description": "QC_EXTRAPOLATE:  Indicates extrapolation is performed out from two points on the same side of the target index.",
+    "bit_4_description": (
+        "QC_EXTRAPOLATE:  Indicates extrapolation is performed out from two points on"
+        " the same side of the target index."
+    ),
     "bit_4_assessment": "Indeterminate",
-    "bit_5_description": "QC_NOT_USING_CLOSEST:  Nearest good point is not the nearest actual point.",
+    "bit_5_description": (
+        "QC_NOT_USING_CLOSEST:  Nearest good point is not the nearest actual point."
+    ),
     "bit_5_assessment": "Indeterminate",
-    "bit_6_description": "QC_SOME_BAD_INPUTS:  Some, but not all, of the inputs in the averaging window were flagged as bad and excluded from the transform.",
+    "bit_6_description": (
+        "QC_SOME_BAD_INPUTS:  Some, but not all, of the inputs in the averaging window"
+        " were flagged as bad and excluded from the transform."
+    ),
     "bit_6_assessment": "Indeterminate",
-    "bit_7_description": "QC_ZERO_WEIGHT:  The weights for all the input points to be averaged for this output bin were set to zero.",
+    "bit_7_description": (
+        "QC_ZERO_WEIGHT:  The weights for all the input points to be averaged for this"
+        " output bin were set to zero."
+    ),
     "bit_7_assessment": "Indeterminate",
-    "bit_8_description": "QC_OUTSIDE_RANGE:  No input samples exist in the transformation region, value set to missing_value.",
+    "bit_8_description": (
+        "QC_OUTSIDE_RANGE:  No input samples exist in the transformation region, value"
+        " set to missing_value."
+    ),
     "bit_8_assessment": "Bad",
-    "bit_9_description": "QC_ALL_BAD_INPUTS:  All the input values in the transformation region are bad, value set to missing_value.",
+    "bit_9_description": (
+        "QC_ALL_BAD_INPUTS:  All the input values in the transformation region are bad,"
+        " value set to missing_value."
+    ),
     "bit_9_assessment": "Bad",
-    "bit_10_description": "QC_BAD_STD:  Standard deviation over averaging interval is greater than limit set by transform parameter std_bad_max.",
+    "bit_10_description": (
+        "QC_BAD_STD:  Standard deviation over averaging interval is greater than limit"
+        " set by transform parameter std_bad_max."
+    ),
     "bit_10_assessment": "Bad",
-    "bit_11_description": "QC_INDETERMINATE_STD:  Standard deviation over averaging interval is greater than limit set by transform parameter std_ind_max.",
+    "bit_11_description": (
+        "QC_INDETERMINATE_STD:  Standard deviation over averaging interval is greater"
+        " than limit set by transform parameter std_ind_max."
+    ),
     "bit_11_assessment": "Indeterminate",
-    "bit_12_description": "QC_BAD_GOODFRAC:  Fraction of good and indeterminate points over averaging interval are less than limit set by transform parameter goodfrac_bad_min.",
+    "bit_12_description": (
+        "QC_BAD_GOODFRAC:  Fraction of good and indeterminate points over averaging"
+        " interval are less than limit set by transform parameter goodfrac_bad_min."
+    ),
     "bit_12_assessment": "Bad",
-    "bit_13_description": "QC_INDETERMINATE_GOODFRAC:  Fraction of good and indeterminate points over averaging interval is less than limit set by transform parameter goodfrac_ind_min.",
+    "bit_13_description": (
+        "QC_INDETERMINATE_GOODFRAC:  Fraction of good and indeterminate points over"
+        " averaging interval is less than limit set by transform parameter"
+        " goodfrac_ind_min."
+    ),
     "bit_13_assessment": "Indeterminate",
 }
 
@@ -180,7 +220,8 @@ class TransformParameterConverter:
             # If this parameter is range and value is LENGTH_OF_PROCESSING_INTERVAL, then we can't save the parameter
             # because ADI doesn't recognize LENGTH_OF_PROCESSING_INTERVAL as a valid option.
             print(
-                "Omitting range=LENGTH_OF_PROCESSING_INTERVAL since it is not recognized by ADI and is the default."
+                "Omitting range=LENGTH_OF_PROCESSING_INTERVAL since it is not"
+                " recognized by ADI and is the default."
             )
 
         else:


### PR DESCRIPTION
This PR replaces all `warnings.warn` calls with `logger.warning` to help improve how logs are captured downstream.