### PR TITLE
Say "Created by..." in the history global attribute

### DIFF
--- a/tsdat/pipeline/base.py
+++ b/tsdat/pipeline/base.py
@@ -116,7 +116,7 @@ class Pipeline(ParameterizedClass, ABC):
             var_attrs = model_to_dict(self.dataset_config[name].attrs)
             dataset[name].attrs.update(var_attrs)
 
-        history = f"Ran by {getuser()} at {datetime.now().isoformat()}"
+        history = f"Created by {getuser()} at {datetime.now().isoformat()}"
         dataset.attrs["history"] = history
 
         return dataset


### PR DESCRIPTION
This is an issue that Bridget has brought up in WFIP3 data reviews. "Created by..." is the same phrasing ARM uses and reads nicer than "Ran by..."