### PR TITLE
Defined units

### DIFF
--- a/test/adi/test_transform.py
+++ b/test/adi/test_transform.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose
 @pytest.fixture
 def input_dataset() -> xr.Dataset:
     # Data points every hour for one day
-    time = pd.date_range(start="2023-02-01", freq="H", periods=24)
+    time = pd.date_range(start="2023-02-01", freq="h", periods=24)
     range_vals = np.array([0, 1])
     input_foo_values = np.linspace((0, 0), (23, 23), num=24)
     input_qc_foo_values = np.zeros((24, 2), dtype=int)

--- a/test/config/yaml/dataset.yaml
+++ b/test/config/yaml/dataset.yaml
@@ -30,21 +30,3 @@ data_vars:
     attrs:
       units: "1"
       _FillValue: null # Should remove the _FillValue attribute entirely
-
-  temp:
-    dims: [time]
-    dtype: float
-    attrs:
-      units: degree_C
-
-  percent:
-    dims: [time]
-    dtype: float
-    attrs:
-      units: "%"
-
-  exponent:
-    dims: [time]
-    dtype: float
-    attrs:
-      units: m s-1

--- a/test/config/yaml/dataset.yaml
+++ b/test/config/yaml/dataset.yaml
@@ -30,3 +30,21 @@ data_vars:
     attrs:
       units: "1"
       _FillValue: null # Should remove the _FillValue attribute entirely
+
+  temp:
+    dims: [time]
+    dtype: float
+    attrs:
+      units: degree_C
+
+  percent:
+    dims: [time]
+    dtype: float
+    attrs:
+      units: "%"
+
+  exponent:
+    dims: [time]
+    dtype: float
+    attrs:
+      units: m s-1

--- a/test/io/test_converters.py
+++ b/test/io/test_converters.py
@@ -29,6 +29,21 @@ def sample_dataset() -> xr.Dataset:
                 [59, 60, 61],
                 {"comment": "test case with no units attr"},
             ),
+            "temp": (
+                "time",
+                [59, 60, 61],
+                {"units": "degree_F"},
+            ),
+            "percent": (
+                "time",
+                [59, 60, 61],
+                {"units": ""},
+            ),
+            "exponent": (
+                "time",
+                [59, 60, 61],
+                {"units": "km s-1"},
+            ),
         },
     )
     return ds
@@ -75,6 +90,40 @@ def test_units_converter(sample_dataset: xr.Dataset, dataset_config: DatasetConf
         sample_dataset["second"], "second", dataset_config, retrieved_dataset
     )
     assert data is None
+    
+
+def test_defined_pint_units(sample_dataset: xr.Dataset, dataset_config: DatasetConfig):
+    retrieved_dataset = RetrievedDataset.from_xr_dataset(sample_dataset)
+    
+    # Manually convert fahrenheit to celcius
+    expected = sample_dataset.assign(temp=lambda x: (x["temp"] - 32) * 5 / 9)  # type: ignore
+    converter = UnitsConverter(input_units=None)
+    data = converter.convert(
+        sample_dataset["temp"], "temp", dataset_config, retrieved_dataset
+    )
+    assert data is not None
+    xr.testing.assert_allclose(data, expected["temp"])  # type: ignore
+    assert data.attrs["units"] == "degree_C"
+    
+    # Convert percent to dimensionless
+    expected = sample_dataset.assign(percent=lambda x: (x["percent"] * 100))  # type: ignore
+    converter = UnitsConverter(input_units=None)
+    data = converter.convert(
+        sample_dataset["percent"], "percent", dataset_config, retrieved_dataset
+    )
+    assert data is not None
+    xr.testing.assert_allclose(data, expected["percent"])  # type: ignore
+    assert data.attrs["units"] == "%"
+    
+    # Convert km s-1 to m s-1
+    expected = sample_dataset.assign(exponent=lambda x: (x["exponent"] * 1000))  # type: ignore
+    converter = UnitsConverter(input_units=None)
+    data = converter.convert(
+        sample_dataset["exponent"], "exponent", dataset_config, retrieved_dataset
+    )
+    assert data is not None
+    xr.testing.assert_allclose(data, expected["exponent"])  # type: ignore
+    assert data.attrs["units"] == "m s-1"
 
 
 def test_stringtime_converter(

--- a/test/io/test_converters.py
+++ b/test/io/test_converters.py
@@ -84,43 +84,45 @@ def test_units_converter(sample_dataset: xr.Dataset, dataset_config: DatasetConf
     )
     assert data is None
 
-    # Test case where there are no input units
-    converter = UnitsConverter()
-    data = converter.convert(
-        sample_dataset["second"], "second", dataset_config, retrieved_dataset
-    )
-    assert data is None
-    
 
 def test_defined_pint_units(sample_dataset: xr.Dataset, dataset_config: DatasetConfig):
     retrieved_dataset = RetrievedDataset.from_xr_dataset(sample_dataset)
-    
+
     # Manually convert fahrenheit to celcius
     expected = sample_dataset.assign(temp=lambda x: (x["temp"] - 32) * 5 / 9)  # type: ignore
-    converter = UnitsConverter(input_units=None)
+    # Use units here since dataset.yaml not updated
+    converter = UnitsConverter()
+    # Sample dataset is the input file, dataset_config shows output
     data = converter.convert(
-        sample_dataset["temp"], "temp", dataset_config, retrieved_dataset
+        sample_dataset["temp"], "first", dataset_config, retrieved_dataset
     )
+
     assert data is not None
     xr.testing.assert_allclose(data, expected["temp"])  # type: ignore
-    assert data.attrs["units"] == "degree_C"
-    
+    assert data.attrs["units"] == "degC"
+
     # Convert percent to dimensionless
     expected = sample_dataset.assign(percent=lambda x: (x["percent"] * 100))  # type: ignore
-    converter = UnitsConverter(input_units=None)
+    converter = UnitsConverter()
+    # Set output units in dataset config
+    dataset_config["first"].attrs.units = "%"
     data = converter.convert(
-        sample_dataset["percent"], "percent", dataset_config, retrieved_dataset
+        sample_dataset["percent"], "first", dataset_config, retrieved_dataset
     )
+
     assert data is not None
     xr.testing.assert_allclose(data, expected["percent"])  # type: ignore
     assert data.attrs["units"] == "%"
-    
+
     # Convert km s-1 to m s-1
     expected = sample_dataset.assign(exponent=lambda x: (x["exponent"] * 1000))  # type: ignore
-    converter = UnitsConverter(input_units=None)
+    converter = UnitsConverter()
+    # Set output units in dataset config
+    dataset_config["first"].attrs.units = "m s-1"
     data = converter.convert(
-        sample_dataset["exponent"], "exponent", dataset_config, retrieved_dataset
+        sample_dataset["exponent"], "first", dataset_config, retrieved_dataset
     )
+
     assert data is not None
     xr.testing.assert_allclose(data, expected["exponent"])  # type: ignore
     assert data.attrs["units"] == "m s-1"

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,7 +12,7 @@ def test_schema_generation():
     with tempfile.TemporaryDirectory() as tmp_dir:
         result = runner.invoke(app, ["generate-schema", "--dir", tmp_dir])
         assert result.exit_code == 0
-        assert f"Using tsdat dataset standards" in result.stdout
+        assert f"tsdat dataset standards" in result.stdout
 
     # acdd
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -20,7 +20,7 @@ def test_schema_generation():
             app, ["generate-schema", "--dir", tmp_dir, "--standards", "acdd"]
         )
         assert result.exit_code == 0
-        assert f"Using acdd dataset standards" in result.stdout
+        assert f"acdd dataset standards" in result.stdout
 
     # ioos
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -28,4 +28,4 @@ def test_schema_generation():
             app, ["generate-schema", "--dir", tmp_dir, "--standards", "ioos"]
         )
         assert result.exit_code == 0
-        assert f"Using ioos dataset standards" in result.stdout
+        assert f"ioos dataset standards" in result.stdout

--- a/tsdat/config/variables/ureg.py
+++ b/tsdat/config/variables/ureg.py
@@ -2,3 +2,8 @@ from pint import UnitRegistry
 
 ureg = UnitRegistry()
 ureg.define("unitless = count = 1")  # type: ignore
+ureg.define('@alias degree_Fahrenheit = degree_F')
+ureg.define('@alias degree_Celsius = degree_C')
+ureg.define('@alias degree_Rankine = degree_R')
+ureg.define('@alias kelvin = Kelvin')
+

--- a/tsdat/config/variables/ureg.py
+++ b/tsdat/config/variables/ureg.py
@@ -1,8 +1,8 @@
+import re
 from pint import UnitRegistry
 
-ureg = UnitRegistry()
-# Dimensionless
-ureg.define("unitless = count = 1")  # type: ignore
+ureg = UnitRegistry(autoconvert_offset_to_baseunit=True)
+
 # Temperature
 ureg.define('@alias degree_Fahrenheit = degree_F')
 ureg.define('@alias degree_Celsius = degree_C')
@@ -10,3 +10,29 @@ ureg.define('@alias degree_Rankine = degree_R')
 ureg.define('@alias kelvin = Kelvin')
 # Percent
 ureg.define('@alias percent = %')
+# Other
+ureg.define('fraction = []')
+ureg.define('unitless = []')
+
+
+def check_unit(unit_str: str, keep_exp: bool) -> str:
+    # Not recognized by pint, but we want it to be valid
+    if unit_str.lower().startswith("seconds since"):
+        return unit_str
+
+    # Add exponent symbol (m2 s-2 -> m^2 s^-2)
+    carrot_flag = 1 if "^" in unit_str else 0
+    unit_exponent = re.compile(
+        r"(?<=[A-Za-z\)])(?![A-Za-z\)])"
+        r"(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
+    )
+    unit_str = unit_exponent.sub("^", unit_str)
+    
+    # Validate with pint unit registry
+    ureg(unit_str)
+    
+    # Remove exponent if not used
+    if not keep_exp and not carrot_flag:
+        unit_str = unit_str.replace("^", "")
+
+    return unit_str

--- a/tsdat/config/variables/ureg.py
+++ b/tsdat/config/variables/ureg.py
@@ -4,15 +4,15 @@ from pint import UnitRegistry
 ureg = UnitRegistry(autoconvert_offset_to_baseunit=True)
 
 # Temperature
-ureg.define('@alias degree_Fahrenheit = degree_F')
-ureg.define('@alias degree_Celsius = degree_C')
-ureg.define('@alias degree_Rankine = degree_R')
-ureg.define('@alias kelvin = Kelvin')
+ureg.define("@alias degree_Fahrenheit = degree_F")
+ureg.define("@alias degree_Celsius = degree_C")
+ureg.define("@alias degree_Rankine = degree_R")
+ureg.define("@alias kelvin = Kelvin")
 # Percent
-ureg.define('@alias percent = %')
+ureg.define("@alias percent = %")
 # Other
-ureg.define('fraction = []')
-ureg.define('unitless = []')
+ureg.define("fraction = []")
+ureg.define("unitless = []")
 
 
 def check_unit(unit_str: str, keep_exp: bool) -> str:
@@ -23,14 +23,13 @@ def check_unit(unit_str: str, keep_exp: bool) -> str:
     # Add exponent symbol (m2 s-2 -> m^2 s^-2)
     carrot_flag = 1 if "^" in unit_str else 0
     unit_exponent = re.compile(
-        r"(?<=[A-Za-z\)])(?![A-Za-z\)])"
-        r"(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
+        r"(?<=[A-Za-z\)])(?![A-Za-z\)])" r"(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
     )
     unit_str = unit_exponent.sub("^", unit_str)
-    
+
     # Validate with pint unit registry
     ureg(unit_str)
-    
+
     # Remove exponent if not used
     if not keep_exp and not carrot_flag:
         unit_str = unit_str.replace("^", "")

--- a/tsdat/config/variables/ureg.py
+++ b/tsdat/config/variables/ureg.py
@@ -1,9 +1,12 @@
 from pint import UnitRegistry
 
 ureg = UnitRegistry()
+# Dimensionless
 ureg.define("unitless = count = 1")  # type: ignore
+# Temperature
 ureg.define('@alias degree_Fahrenheit = degree_F')
 ureg.define('@alias degree_Celsius = degree_C')
 ureg.define('@alias degree_Rankine = degree_R')
 ureg.define('@alias kelvin = Kelvin')
-
+# Percent
+ureg.define('@alias percent = %')

--- a/tsdat/config/variables/variable_attributes.py
+++ b/tsdat/config/variables/variable_attributes.py
@@ -1,3 +1,4 @@
+import re
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -217,10 +218,15 @@ class VariableAttributes(AttributeModel):
     @validator("units")
     def validate_unit(cls, unit_str: str) -> str:
         # Not recognized by pint, but we want it to be valid
-        if unit_str == "%" or unit_str.lower().startswith("seconds since"):
+        if unit_str.lower().startswith("seconds since"):
             return unit_str
         # Validate with pint unit registry
         try:
+            # Add exponent symbol (m2 s-2 -> m^2 s^-2)
+            unit_exponent = re.compile(r'(?<=[A-Za-z\)])(?![A-Za-z\)])'
+                           r'(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])')
+            unit_str = unit_exponent.sub("^", unit_str)
+            # Get unit
             ureg(unit_str)
         except PintError:
             logger.warning(

--- a/tsdat/config/variables/variable_attributes.py
+++ b/tsdat/config/variables/variable_attributes.py
@@ -223,8 +223,10 @@ class VariableAttributes(AttributeModel):
         # Validate with pint unit registry
         try:
             # Add exponent symbol (m2 s-2 -> m^2 s^-2)
-            unit_exponent = re.compile(r'(?<=[A-Za-z\)])(?![A-Za-z\)])'
-                           r'(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])')
+            unit_exponent = re.compile(
+                r"(?<=[A-Za-z\)])(?![A-Za-z\)])"
+                r"(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
+            )
             unit_str = unit_exponent.sub("^", unit_str)
             # Get unit
             ureg(unit_str)

--- a/tsdat/config/variables/variable_attributes.py
+++ b/tsdat/config/variables/variable_attributes.py
@@ -10,7 +10,7 @@ from pydantic import (
     validator,
 )
 
-from .ureg import ureg
+from .ureg import check_unit
 from ..attributes import AttributeModel
 
 logger = logging.getLogger(__name__)
@@ -217,19 +217,9 @@ class VariableAttributes(AttributeModel):
 
     @validator("units")
     def validate_unit(cls, unit_str: str) -> str:
-        # Not recognized by pint, but we want it to be valid
-        if unit_str.lower().startswith("seconds since"):
-            return unit_str
-        # Validate with pint unit registry
         try:
-            # Add exponent symbol (m2 s-2 -> m^2 s^-2)
-            unit_exponent = re.compile(
-                r"(?<=[A-Za-z\)])(?![A-Za-z\)])"
-                r"(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])"
-            )
-            unit_str = unit_exponent.sub("^", unit_str)
-            # Get unit
-            ureg(unit_str)
+            # Validate with pint unit registry
+            unit_str = check_unit(unit_str, keep_exp=False)
         except PintError:
             logger.warning(
                 f"'{unit_str}' is not a valid unit or combination of units. The string"

--- a/tsdat/config/variables/variable_attributes.py
+++ b/tsdat/config/variables/variable_attributes.py
@@ -217,7 +217,7 @@ class VariableAttributes(AttributeModel):
     @validator("units")
     def validate_unit(cls, unit_str: str) -> str:
         # Not recognized by pint, but we want it to be valid
-        if unit_str == "%" or unit_str.startswith("Seconds since"):
+        if unit_str == "%" or unit_str.lower().startswith("seconds since"):
             return unit_str
         # Validate with pint unit registry
         try:

--- a/tsdat/io/converters/units_converter.py
+++ b/tsdat/io/converters/units_converter.py
@@ -43,11 +43,11 @@ class UnitsConverter(DataConverter):
         # Get input units and convert udunits for pint if need be
         input_units = self._get_input_units(data)
         input_units = check_unit(input_units, keep_exp=True)
-        
+
         # Assume if no units supplied, variable is dimensionless
         if not input_units:
             logger.warning(
-                "Input units for variable '%s' could not be found. Assuming variable " 
+                "Input units for variable '%s' could not be found. Assuming variable "
                 "'%s' is dimensionless.",
                 variable_name,
                 variable_name,
@@ -55,13 +55,9 @@ class UnitsConverter(DataConverter):
 
         output_units = dataset_config[variable_name].attrs.units
         output_units = check_unit(output_units, keep_exp=True)
-        
+
         out_dtype = dataset_config[variable_name].dtype
-        if (
-            not output_units
-            or output_units == "1"
-            or input_units == output_units
-        ):
+        if not output_units or output_units == "1" or input_units == output_units:
             if not output_units:
                 logger.warning(
                     "Output units for variable %s could not be found. Please ensure"
@@ -78,7 +74,7 @@ class UnitsConverter(DataConverter):
         # Set output datatype from dataset config
         converted = converted.astype(out_dtype)
         data_array = data.copy(data=converted)
-        
+
         # Use original output units text
         data_array.attrs["units"] = dataset_config[variable_name].attrs.units
         logger.debug(


### PR DESCRIPTION
Fix for issue #177

- Will take correct CF version of temperature units 
- Will take units that don't include exponent symbols (i.e. m s-1 instead of m/s)
- Removed requirement for units attribute - if no units are supplied, the variable is assumed dimensionless
- Will now allow ability to convert dimensionless unit ("unitless", "", or None) to percent ("percent" or "%") (i.e 1.0 -> 100%)


