### PR TITLE
Improve template strings

### DIFF
--- a/test/io/test_storage.py
+++ b/test/io/test_storage.py
@@ -166,7 +166,7 @@ def test_fetch_returns_empty(
     expected_dataset = xr.Dataset()  # empty
     dataset = storage.fetch_data(
         start=datetime.fromisoformat("2022-04-10 00:00:00"),
-        end=datetime.fromisoformat("2022-04-10 23:00:00"),
+        end=datetime.fromisoformat("2022-04-11 00:00:00"),
         datastream="sgp.testing-storage.a0",
         metadata_kwargs=dict(location_id="sgp"),
     )

--- a/test/io/test_storage.py
+++ b/test/io/test_storage.py
@@ -161,12 +161,12 @@ def test_fetch_returns_empty(
     storage: FileSystem | FileSystemS3 | ZarrLocalStorage = request.getfixturevalue(
         storage_fixture
     )
-    storage.parameters.data_storage_path /= "{year}/{month}/{day}"
+    storage.parameters.data_storage_path /= "{yyyy}/{mm}/{dd}"
 
     expected_dataset = xr.Dataset()  # empty
     dataset = storage.fetch_data(
         start=datetime.fromisoformat("2022-04-10 00:00:00"),
-        end=datetime.fromisoformat("2022-04-11 00:00:00"),
+        end=datetime.fromisoformat("2022-04-10 23:00:00"),
         datastream="sgp.testing-storage.a0",
         metadata_kwargs=dict(location_id="sgp"),
     )

--- a/tsdat/const/const.py
+++ b/tsdat/const/const.py
@@ -7,10 +7,11 @@ OUTPUT_DATASTREAM = "output_ds"
 InputKey = str
 VarName = str
 
+
 DATASTREAM_TEMPLATE = Template(
     "{location_id}.{dataset_name}[-{qualifier}][-{temporal}].{data_level}"
 )
 
 FILENAME_TEMPLATE = Template(
-    "{datastream}.{start_date}.{start_time}[.{title}].{extension}"
+    "{datastream}.{yyyy}{mm}{dd}.{HH}{MM}{SS}[.{title}].{extension}"
 )

--- a/tsdat/io/base/storage.py
+++ b/tsdat/io/base/storage.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import (
     Any,
+    Callable,
     Dict,
     Generator,
     List,
@@ -227,25 +228,20 @@ class Storage(ParameterizedClass, ABC):
         Returns:
             Path: The path to the ancillary file.
         """
+        substitutions = self._get_substitutions(
+            title=title,
+            dataset=dataset,
+            datastream=datastream,
+            start=start,
+            extension=extension,
+            extra=kwargs,
+        )
+        filepath_template = (
+            Template(self.parameters.ancillary_storage_path)
+            / self.parameters.ancillary_filename_template
+        )
+        ancillary_path = Path(filepath_template.substitute(substitutions))
 
-        # Override with provided substitutions and keywords, if provided
-        substitutions = {}
-        if dataset is not None:
-            substitutions.update(get_fields_from_dataset(dataset))
-        if datastream is not None:
-            substitutions.update(
-                datastream=datastream, **get_fields_from_datastream(datastream)
-            )
-        if start is not None:
-            substitutions.update(datetime_substitutions(start))
-        substitutions.update(extension=extension, ext=extension, title=title, **kwargs)
-
-        # Resolve substitutions to get ancillary filepath
-        dir_template = Template(self.parameters.ancillary_storage_path)
-        file_template = Template(self.parameters.ancillary_filename_template)
-        dirpath = dir_template.substitute(substitutions)
-        filename = file_template.substitute(substitutions)
-        ancillary_path = Path(dirpath) / filename
         if root_dir is not None:
             ancillary_path = root_dir / ancillary_path
 
@@ -322,3 +318,52 @@ class Storage(ParameterizedClass, ABC):
                 self.save_ancillary_file(path, target_path=target)
 
         tmp_dir.cleanup()
+
+    def _get_substitutions(
+        self,
+        datastream: str | None = None,
+        start: datetime | None = None,
+        time_range: tuple[datetime, datetime] | None = None,
+        dataset: xr.Dataset | None = None,
+        extra: dict[str, str] | None = None,
+        extension: str | None = None,
+        title: str | None = None,
+    ) -> Dict[str, Callable[[], str] | str]:
+        """Gets substitutions for file extension and datastream components."""
+        sub: dict[str, Callable[[], str] | str] = {}
+
+        if extension is not None:
+            sub.update(ext=extension, extension=extension)
+
+        if start:
+            sub.update(datetime_substitutions(start))
+
+        # Get substitutions for year/month/day
+        if time_range is not None:
+            start, end = time_range
+            if start.year == end.year:
+                sub["year"] = start.strftime("%Y")  # yyyy
+                sub["yyyy"] = start.strftime("%Y")
+                if start.month == end.month:
+                    sub["month"] = start.strftime("%m")  # mm
+                    sub["mm"] = start.strftime("%m")
+                    if start.day == end.day:
+                        sub["day"] = start.strftime("%d")  # dd
+                        sub["dd"] = start.strftime("%d")
+
+        if dataset is not None:
+            sub.update(get_fields_from_dataset(dataset))
+
+        if extra is not None:
+            sub.update(extra)
+
+        if datastream is not None:
+            sub.update(
+                datastream=datastream,
+                **get_fields_from_datastream(datastream),
+            )
+
+        if title is not None:
+            sub.update(title=title)
+
+        return sub

--- a/tsdat/io/base/storage.py
+++ b/tsdat/io/base/storage.py
@@ -166,12 +166,11 @@ class Storage(ParameterizedClass, ABC):
     def get_ancillary_filepath(
         self,
         title: str,
+        root_dir: Path,
         extension: str = "png",
         dataset: Union[xr.Dataset, None] = None,
         datastream: Union[str, None] = None,
         start: Union[datetime, None] = None,
-        root_dir: Union[Path, None] = None,
-        mkdirs: bool = True,
         **kwargs: str,
     ) -> Path:
         """Returns the filepath for the given datastream and title of an ancillary file
@@ -241,13 +240,8 @@ class Storage(ParameterizedClass, ABC):
             / self.parameters.ancillary_filename_template
         )
         ancillary_path = Path(filepath_template.substitute(substitutions))
-
-        if root_dir is not None:
-            ancillary_path = root_dir / ancillary_path
-
-        if mkdirs:
-            ancillary_path.parent.mkdir(exist_ok=True, parents=True)
-
+        ancillary_path = root_dir / ancillary_path
+        ancillary_path.parent.mkdir(exist_ok=True, parents=True)
         return ancillary_path
 
     @abstractmethod

--- a/tsdat/io/base/storage.py
+++ b/tsdat/io/base/storage.py
@@ -14,7 +14,6 @@ from typing import (
 import xarray as xr
 from pydantic import BaseSettings, Field
 
-from .data_handler import DataHandler
 from ...tstring import Template
 from ...utils import (
     ParameterizedClass,
@@ -22,6 +21,7 @@ from ...utils import (
     get_fields_from_dataset,
     get_fields_from_datastream,
 )
+from .data_handler import DataHandler
 
 
 class Storage(ParameterizedClass, ABC):
@@ -63,7 +63,7 @@ class Storage(ParameterizedClass, ABC):
         Defaults to ``ancillary/{location_id}/{datastream}``."""
 
         ancillary_filename_template: str = (
-            "{datastream}.{date_time}.{title}.{extension}"
+            "{datastream}.{yyyy}{mm}{dd}.{HH}{MM}{SS}.{title}.{extension}"
         )
         """Template string to use for ancillary filenames.
         

--- a/tsdat/io/storage/file_system_s3.py
+++ b/tsdat/io/storage/file_system_s3.py
@@ -158,7 +158,9 @@ class FileSystemS3(FileSystem):
     ) -> List[datetime]:
         """Returns the data datetimes of all files modified after the specified time."""
         filepath_glob = self.data_filepath_template.substitute(
-            self._get_substitutions(datastream=datastream),
+            self._get_substitutions(
+                datastream=datastream,
+            ),
             allow_missing=True,
             fill=".*",
         )
@@ -211,7 +213,11 @@ class FileSystemS3(FileSystem):
     def save_data(self, dataset: xr.Dataset, **kwargs: Any):
         filepath = Path(
             self.data_filepath_template.substitute(
-                self._get_substitutions(dataset=dataset),
+                self._get_substitutions(
+                    dataset=dataset,
+                    extension=self.handler.extension
+                    or self.handler.writer.file_extension,
+                ),
                 allow_missing=False,
             )
         )
@@ -238,14 +244,10 @@ class FileSystemS3(FileSystem):
         **kwargs: Any,
     ) -> List[Path]:
         substitutions = self._get_substitutions(
-            datastream=datastream,
-            time_range=(start, end),
-            extra=metadata_kwargs,
+            datastream=datastream, time_range=(start, end), extra=metadata_kwargs
         )
         filepath_glob = self.data_filepath_template.substitute(
-            substitutions,
-            allow_missing=True,
-            fill=".*",
+            substitutions, allow_missing=True, fill=".*"
         )
         matches = self._get_matching_s3_objects(filepath_glob)
         paths = [Path(obj.key) for obj in matches]

--- a/tsdat/tstring.py
+++ b/tsdat/tstring.py
@@ -2,101 +2,104 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Callable, Mapping, Match
+from typing import Callable, Mapping
 
 __all__ = ("Template",)
 
-_SQUARE_BRACKET_REGEX = r"\[(.*?)\]"
-_CURLY_BRACKET_REGEX = r"\{(.*?)\}"
+
+def _is_balanced(template: str) -> bool:
+    stack: list[str] = []
+    for char in template:
+        if char in "{[":
+            stack.append("}" if char == "{" else "]")
+        elif char in "}]":
+            if not stack or char != stack.pop():
+                return False
+    return len(stack) == 0
 
 
-def _substitute(
-    template: str,
-    mapping: Mapping[str, str | Callable[[], str] | None] | None = None,
-    allow_missing: bool = False,
-    fill: str | None = None,  # TODO
-    **kwds: str | Callable[[], str] | None,
-) -> str:
-    """Substitutes variables in a template string.
+class TemplateChunk:
+    """Class to hold a chunk of a Template.
 
-    The template string is expected to be formatted in the same way as python f-strings,
-    with variables that should be substituted wrapped in curly braces `{}`.
-    Additionally, square brackets may be used around curly brackets and other text to
-    mark that substitution as optional -- i.e. if the variable cannot be found then the
-    text wrapped in the square brackets will be removed.
+    A chunk is a smaller part of a template. E.g., the template "{a}{b}{c}d" has 4
+    chunks: "{a}", "{b}", "{c}", and "d"."""
 
-    Examples:
+    def __init__(self, chunk: str) -> None:
+        if not _is_balanced(chunk):
+            raise ValueError(f"Unbalanced brackets in chunk: '{chunk}'")
+        self.str = chunk
+        self.var_name = self._get_variable_name(chunk)
+        self.parts = self._get_parts(chunk)
+        self.is_required = self._is_required(chunk)
+        self.regex = self._generate_regex(chunk)
 
-        `mapping = dict(a="x", b="y", c="z")`
+    @staticmethod
+    def _get_variable_name(chunk: str) -> str | None:
+        if "{" in chunk:
+            start, stop = chunk.index("{"), chunk.index("}")
+            return chunk[start + 1 : stop]
+        return None
 
-        `substitute("{a}.{b}{c}w", mapping) == "x.yzw"  # True`
+    @staticmethod
+    def _get_parts(chunk: str) -> tuple[str, ...]:
+        return tuple(re.split(r"[{}\[\]]", chunk))
 
-        `substitute("{a}.{b}[.{c}]", mapping) == "x.y.z"  # True`
+    @staticmethod
+    def _is_required(chunk: str) -> bool | None:
+        if "{" in chunk:
+            return "[" not in chunk
+        return None
 
-        `substitute("{a}.{b}[.{d}]", mapping) == "x.y"  # True`
-
-        `substitute("{a}.{b}.{d}", mapping, True) == "x.y.{d}"  # True`
-
-        `substitute("{a}.{b}.{d}", mapping, False)  # raises ValueError`
-
-    Args:
-        template (str): The template string. Variables to substitute should be wrapped
-            by curly braces `{}`.
-        mapping (Mapping[str, str | Callable[[], str] | None] | None): A key-value pair
-            of variable name to the value to replace it with. If the value is a string
-            it is dropped-in directly. If it is a no-argument callable the return value
-            of the callable is used. If it is None, then it is treated as missing and
-            the action taken depends on the `allow_missing` parameter.
-        allow_missing (bool, optional): Allow variables outside of square brackets to be
-            missing, in which case they are left as-is, including the curly brackets.
-            This is intended to allow users to perform some variable substitutions
-            before all variables in the mapping are known. Defaults to False.
-        fill (str, optional): Value to use to fill in missing substitutions
-            (e.g., "*"). Only applied if allow_missing=True. If None (the default) then
-            no values will be filled.
-        **kwds (str | Callable[[], str] | None): Optional extras to be merged into the
-            mapping dict. If a keyword passed here has the same name as a key in the
-            mapping dict, the value here would be used instead.
-
-    Raises:
-        ValueError: If the substitutions cannot be made due to missing variables.
-
-    Returns:
-        str: The template string with the appropriate substitutions made.
-    """
-    if mapping is None:
-        mapping = {}
-    mapping = {**mapping, **kwds}
-
-    def _sub_curly(match: Match[str]) -> str:
-        # group(1) returns string without {}, group(0) returns with {} result is we only
-        # do replacements that we can actually do.
-        key, full_match = match.group(1), match.group(0)
-        res = mapping.get(key)
-        if callable(res):
-            res = res()
-        if allow_missing and res is None:
-            if fill is not None:
-                res = fill
+    @staticmethod
+    def _generate_regex(chunk: str) -> str:
+        regex_pattern = ""
+        i = 0
+        while i < len(chunk):
+            char = chunk[i]
+            if char == "{":
+                var_start = i + 1
+                var_end = chunk.index("}", var_start)
+                var_name = chunk[var_start:var_end]
+                regex_pattern += f"(?P<{var_name}>[_a-zA-Z0-9]+)"
+                i = var_end + 1
+            elif char == "[":
+                regex_pattern += "(?:"
+                i += 1
+            elif char == "]":
+                regex_pattern += ")?"
+                i += 1
             else:
-                res = full_match  # original curly brace string -- no replacements done
-        elif res is None:
-            raise ValueError(f"Substitution cannot be made for key '{match.group(1)}'")
-        return res
+                regex_pattern += re.escape(char)
+                i += 1
+        return regex_pattern
 
-    def _sub_square(match: Match[str]) -> str:
-        # make curly substitutions inside of square brackets or remove the whole thing
-        # if substitutions cannot be made.
-        try:
-            resolved = re.sub(_CURLY_BRACKET_REGEX, _sub_curly, match.group(1))
-            return resolved if resolved != match.group(1) else ""
-        except ValueError:
-            return ""
+    def sub(
+        self,
+        value: str | (Callable[[], str]) | None,
+        allow_missing: bool = False,
+        fill: str | None = None,
+    ) -> str:
+        def remove_square_brackets(s: str) -> str:
+            return s if self.is_required else s[1:-1]
 
-    squared = re.sub(_SQUARE_BRACKET_REGEX, _sub_square, template)
-    resolved = re.sub(_CURLY_BRACKET_REGEX, _sub_curly, squared)
+        if callable(value):
+            value = value()
 
-    return resolved
+        result = ""
+        if self.var_name is None:
+            result = self.str
+        elif value is not None:
+            result = self.str.replace(f"{{{self.var_name}}}", value)
+            result = remove_square_brackets(result)
+        elif allow_missing and fill:
+            result = fill
+        elif allow_missing:
+            result = self.str
+        elif self.is_required:
+            raise ValueError(
+                f"Could not make substitution for {self.var_name} in {self}"
+            )
+        return result
 
 
 class Template:
@@ -136,7 +139,11 @@ class Template:
         if not self._is_balanced(_template):
             raise ValueError(f"Unbalanced brackets in template string: '{template}'")
         self._template = _template
-        self.regex = regex or self._generate_regex(_template)
+        self.chunks = self._get_chunks(_template)
+        self.regex = regex or self._generate_regex(self.chunks)
+        self.variables = tuple(
+            chunk.var_name for chunk in self.chunks if chunk.var_name is not None
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._template!r})"
@@ -153,7 +160,13 @@ class Template:
         return self
 
     @staticmethod
-    def _generate_regex(template: str) -> str:
+    def _get_chunks(template: str) -> tuple[TemplateChunk, ...]:
+        pattern = re.compile(r"\{[^}]*\}|\[[^\]]*\]|[^[\]{}]+")
+        matches = pattern.findall(template)
+        return tuple(TemplateChunk(match) for match in matches)
+
+    @staticmethod
+    def _generate_regex(chunks: tuple[TemplateChunk, ...]) -> str:
         """Generates a regex pattern which can be used to extract the values substituted
         into a template string.
 
@@ -164,39 +177,14 @@ class Template:
             str: The regex pattern with named groups according to the template.
         """
         regex_pattern = "^"
-
-        i = 0
-        while i < len(template):
-            char = template[i]
-            if char == "{":
-                var_start = i + 1
-                var_end = template.index("}", var_start)
-                var_name = template[var_start:var_end]
-                regex_pattern += f"(?P<{var_name}>[_a-zA-Z0-9]+)"
-                i = var_end + 1
-            elif char == "[":
-                regex_pattern += "(?:"
-                i += 1
-            elif char == "]":
-                regex_pattern += ")?"
-                i += 1
-            else:
-                regex_pattern += re.escape(char)
-                i += 1
-
+        for chunk in chunks:
+            regex_pattern += chunk.regex
         regex_pattern += "$"
         return regex_pattern
 
     @staticmethod
     def _is_balanced(template: str) -> bool:
-        stack: list[str] = []
-        for char in template:
-            if char in "{[":
-                stack.append("}" if char == "{" else "]")
-            elif char in "}]":
-                if not stack or char != stack.pop():
-                    return False
-        return len(stack) == 0
+        return _is_balanced(template)
 
     @property
     def template(self) -> str:
@@ -204,11 +192,11 @@ class Template:
 
     @template.setter
     def template(self, _template: str | Path):
-        _template = str(_template)
-        if not self._is_balanced(_template):
-            raise ValueError(f"Unbalanced brackets in template string: '{_template}'")
-        self._template = _template
-        self.regex = self._generate_regex(_template)
+        new = Template(_template)
+        self._template = new._template
+        self.chunks = new.chunks
+        self.regex = new.regex
+        self.variables = new.variables
 
     def substitute(
         self,
@@ -242,7 +230,23 @@ class Template:
         Returns:
             str: The template string with the appropriate substitutions made.
         """
-        return _substitute(self._template, mapping, allow_missing, fill=fill, **kwds)
+        if mapping is None:
+            mapping = {}
+        mapping = {**mapping, **kwds}
+        mapping = {k: v for k, v in mapping.items() if v is not None}
+
+        results: list[str] = []
+        for chunk in self.chunks:
+            results.append(
+                chunk.sub(
+                    value=mapping.get(chunk.var_name)
+                    if chunk.var_name is not None
+                    else None,
+                    allow_missing=allow_missing,
+                    fill=fill,
+                )
+            )
+        return "".join(results)
 
     def extract_substitutions(self, formatted_str: str) -> dict[str, str] | None:
         """Extracts the substitutions used to create the provided formatted string.

--- a/tsdat/tstring.py
+++ b/tsdat/tstring.py
@@ -33,6 +33,9 @@ class TemplateChunk:
         self.is_required = self._is_required(chunk)
         self.regex = self._generate_regex(chunk)
 
+    def __repr__(self) -> str:
+        return f"TemplateChunk({self.str})"
+
     @staticmethod
     def _get_variable_name(chunk: str) -> str | None:
         if "{" in chunk:

--- a/tsdat/utils/datetime_substitutions.py
+++ b/tsdat/utils/datetime_substitutions.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Union
+from typing import Callable, Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -7,27 +7,31 @@ import pandas as pd
 
 def datetime_substitutions(
     time: Union[datetime, np.datetime64, None],
-) -> Dict[str, str]:
-    substitutions: Dict[str, str] = {}
+) -> Dict[str, Callable[[], str]]:
+    substitutions: Dict[str, Callable[[], str]] = {}
     if time is not None:
         t = pd.to_datetime(time)
         substitutions.update(
-            year=t.strftime("%Y"),
-            month=t.strftime("%m"),
-            day=t.strftime("%d"),
-            hour=t.strftime("%H"),
-            minute=t.strftime("%M"),
-            second=t.strftime("%S"),
-            yyyy=t.strftime("%Y"),
-            mm=t.strftime("%m"),
-            dd=t.strftime("%d"),
-            HH=t.strftime("%H"),
-            MM=t.strftime("%M"),
-            SS=t.strftime("%S"),
-            date_time=t.strftime("%Y%m%d.%H%M%S"),
-            date=t.strftime("%Y%m%d"),
-            time=t.strftime("%H%M%S"),
-            start_date=t.strftime("%Y%m%d"),  # included for backwards compatibility
-            start_time=t.strftime("%H%M%S"),  # included for backwards compatibility
+            year=lambda: t.strftime("%Y"),
+            month=lambda: t.strftime("%m"),
+            day=lambda: t.strftime("%d"),
+            hour=lambda: t.strftime("%H"),
+            minute=lambda: t.strftime("%M"),
+            second=lambda: t.strftime("%S"),
+            yyyy=lambda: t.strftime("%Y"),
+            mm=lambda: t.strftime("%m"),
+            dd=lambda: t.strftime("%d"),
+            HH=lambda: t.strftime("%H"),
+            MM=lambda: t.strftime("%M"),
+            SS=lambda: t.strftime("%S"),
+            date_time=lambda: t.strftime("%Y%m%d.%H%M%S"),
+            date=lambda: t.strftime("%Y%m%d"),
+            time=lambda: t.strftime("%H%M%S"),
+            start_date=lambda: t.strftime(
+                "%Y%m%d"
+            ),  # included for backwards compatibility
+            start_time=lambda: t.strftime(
+                "%H%M%S"
+            ),  # included for backwards compatibility
         )
     return substitutions

--- a/tsdat/utils/get_filename.py
+++ b/tsdat/utils/get_filename.py
@@ -1,8 +1,10 @@
 from typing import Optional
+
 import xarray as xr
 
 from tsdat.const import FILENAME_TEMPLATE
-from .get_start_date_and_time_str import get_start_date_and_time_str
+
+from .get_fields_from_dataset import get_fields_from_dataset
 
 
 def get_filename(
@@ -30,13 +32,6 @@ def get_filename(
         str: The filename constructed from provided parameters.
 
     ---------------------------------------------------------------------------------"""
-    extension = extension.lstrip(".")
-
-    start_date, start_time = get_start_date_and_time_str(dataset)
-    return FILENAME_TEMPLATE.substitute(
-        dataset.attrs,  # type: ignore
-        extension=extension,
-        title=title,
-        start_date=start_date,
-        start_time=start_time,
-    )
+    substitutions = dict(extension=extension.lstrip("."), title=title)
+    substitutions.update(get_fields_from_dataset(dataset))
+    return FILENAME_TEMPLATE.substitute(substitutions)


### PR DESCRIPTION
This PR makes some changes to the `tstring` and `io.storage` submodules to improve how robustly `tsdat` is able to find files matching the filepath template.

Notable changes include:

* Using `allow_missing=True` in `tstring.Template.substitute` will now no longer remove the unsubstituted components (e.g., `Template("{a}.{b}[.{c}]").substitute(a="1", allow_missing=True) --> "1.{b}[.{c}]"`). 
* In `FileSystem`/`FileSystemS3` filepath templates: using `fill='*'` sometimes resulted in invalid glob patterns due to repeated `*` characters. This has been fixed.
* Added `{yyyy}`, `{mm}`, `{dd}`, `{HH}`, `{MM}`, and `{SS}` datetime substitutions.