### PR TITLE
Optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,65 +1,65 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 
 [project]
-name = "tsdat"
-dynamic = ["version"]
 authors = [
   { name="tsdat", email="tsdat@pnnl.gov" },
 ]
-description = "A data processing framework used to convert time series data into standardized format."
-readme = "README.md"
-requires-python = ">=3.8"
-keywords = ["data", "pipeline"]
-license = {file = "LICENSE.md"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
 ]
-
 dependencies = [    
-  "xarray[io]",
-  "pandas[hdf5, parquet]",
-  "netCDF4 <=1.7.0",
-  "h5netcdf",
-  "pyarrow",
-  "cftime",
-  "xarray",
   "act-atmos >=1.1.3,!=1.3.1,!=1.3.3",
+  "cftime",
+  "dunamai==1.9.0",
+  "jsonpointer==2.2",
+  "netCDF4 <=1.7.0",
+  "numpy >=1.2",
+  "pandas >=1.2",
+  "pint",
   "pydantic >=1.10.0, <2.0.0",
   "pyyaml >=5.4",
-  "numpy >= 1.2",
-  "pandas >= 1.2",
-  "jsonpointer==2.2",
-  "dunamai==1.9.0",
-  "zarr",
-  "typer >=0.4",
   "rich",
-  "types-PyYAML",
-  "boto3",
-  "boto3-stubs[essential]",
-  "mhkit",
+  "typer >=0.4",
+  "xarray",
 ]
+description = "A data processing framework used to convert time series data into standardized format."
+dynamic = ["version"]
+keywords = ["data", "pipeline"]
+license = {file = "LICENSE.md"}
+name = "tsdat"
+readme = "README.md"
+requires-python = ">=3.10"
+
 
 [project.optional-dependencies]
+aws = ["boto3"]
+complete = ["tsdat[aws,io,ocean]"]
 dev = [
-  "pytest",
-  "coverage",
-  "build",
   "black",
-  "ruff",
-  "isort",
-  "moto[s3,sts]==4.0.1"
-]
-docs = [
+  "boto3-stubs[essential]",
+  "build",
+  "coverage",
+  "mkdocs-gen-files",
+  "mkdocs-literate-nav",
   "mkdocs-material",
   "mkdocstrings[python]",
-  "mkdocs-literate-nav",
-  "mkdocs-gen-files",
+  "moto[s3,sts]==4.0.1",
+  "mypy",
+  "pytest",
+  "ruff",
+  "types-PyYAML",
 ]
+io = [
+  "zarr",
+  "pyarrow",
+  "h5netcdf"
+]
+ocean = ["mhkit"]
 
 [project.scripts]
 tsdat = "tsdat.main:app"
@@ -79,6 +79,6 @@ version = {attr = "tsdat._version.__version__"}
 
 [tool.pytest.ini_options]
 # To run all non-adi-dependent tests: `pytest -m "not requres_adi"`
-markers = "requires_adi: mark test as requiring arm data integrator (adi) python/c libraries"
 addopts = "-x"
+markers = "requires_adi: mark test as requiring arm data integrator (adi) python/c libraries"
 testpaths = "test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,14 +51,15 @@ dev = [
   "mkdocstrings[python]",
   "moto[s3,sts]==4.0.1",
   "mypy",
+  "pandas-stubs",
   "pytest",
   "ruff",
   "types-PyYAML",
 ]
 io = [
-  "zarr",
+  "h5netcdf",
   "pyarrow",
-  "h5netcdf"
+  "zarr",
 ]
 ocean = ["mhkit"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ requires-python = ">=3.10"
 aws = ["boto3"]
 complete = ["tsdat[aws,io,ocean]"]
 dev = [
+  "tsdat[complete]",
   "black",
   "boto3-stubs[essential]",
   "build",

--- a/tsdat/qc/checkers/oceanography/check_goring_nikora_2002.py
+++ b/tsdat/qc/checkers/oceanography/check_goring_nikora_2002.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel, Extra
-from numpy.typing import NDArray
+import numpy as np
 import xarray as xr
-from mhkit.dolfyn.adv.clean import GN2002
+from numpy.typing import NDArray
+from pydantic import BaseModel, Extra
 
 from ...base import QualityChecker
 
@@ -25,5 +25,7 @@ class CheckGoringNikora2002(QualityChecker):
 
     parameters: Parameters = Parameters()
 
-    def run(self, dataset: xr.Dataset, variable_name: str) -> NDArray[bool]:
+    def run(self, dataset: xr.Dataset, variable_name: str) -> NDArray[np.bool_]:
+        from mhkit.dolfyn.adv.clean import GN2002
+
         return GN2002(dataset[variable_name], npt=self.parameters.n_points)

--- a/tsdat/qc/handlers/cubic_spline_interp.py
+++ b/tsdat/qc/handlers/cubic_spline_interp.py
@@ -1,10 +1,9 @@
-import xarray as xr
 import numpy as np
+import xarray as xr
 from numpy.typing import NDArray
 from pydantic import BaseModel, Extra
 
 from tsdat import QualityHandler
-from mhkit.dolfyn.adv.clean import clean_fill
 
 
 class CubicSplineInterp(QualityHandler):
@@ -41,6 +40,8 @@ class CubicSplineInterp(QualityHandler):
     def run(
         self, dataset: xr.Dataset, variable_name: str, failures: NDArray[np.bool_]
     ) -> xr.Dataset:
+        from mhkit.dolfyn.adv.clean import clean_fill
+
         if failures.any():
             dataset[variable_name] = clean_fill(
                 dataset[variable_name],


### PR DESCRIPTION
This PR adds some dependency classifiers so users don't need to install all possible `tsdat` dependencies in order to use the library. The new classifiers are:

* `tsdat[aws]`: Installs `boto3`
* `tsdat[io]`: Installs `h5netcdf`, `pyarrow`, and `zarr`. Note that `netcdf4` is still included in `tsdat` by default.
* `tsdat[ocean]`: Installs `mhkit`, as used by `CheckGoringNikora2002` and `CubicSplineInterp`


There is also `tsdat[complete]` which installs all of the above, and `tsdat[dev]` which installs all of the above and some additional libraries used for testing and development of `tsdat`.


closes #95 