### PR TITLE
Revert pipeline code hook signatures

### DIFF
--- a/tsdat/pipeline/pipelines/ingest_pipeline.py
+++ b/tsdat/pipeline/pipelines/ingest_pipeline.py
@@ -6,8 +6,8 @@ from pydantic import PrivateAttr
 
 from tsdat.utils import decode_cf
 
-from .add_inputs_attr import add_inputs_attr
 from ..base import Pipeline
+from .add_inputs_attr import add_inputs_attr
 
 
 class IngestPipeline(Pipeline):
@@ -48,8 +48,7 @@ class IngestPipeline(Pipeline):
             self.hook_plot_dataset(dataset)
         return dataset
 
-    @staticmethod
-    def hook_customize_dataset(dataset: xr.Dataset) -> xr.Dataset:
+    def hook_customize_dataset(self, dataset: xr.Dataset) -> xr.Dataset:
         """-----------------------------------------------------------------------------
         Code hook to customize the retrieved dataset prior to qc being applied.
 
@@ -63,8 +62,7 @@ class IngestPipeline(Pipeline):
         -----------------------------------------------------------------------------"""
         return dataset
 
-    @staticmethod
-    def hook_finalize_dataset(dataset: xr.Dataset) -> xr.Dataset:
+    def hook_finalize_dataset(self, dataset: xr.Dataset) -> xr.Dataset:
         """-----------------------------------------------------------------------------
         Code hook to finalize the dataset after qc is applied but before it is saved.
 

--- a/tsdat/pipeline/pipelines/transformation_pipeline.py
+++ b/tsdat/pipeline/pipelines/transformation_pipeline.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel
 from tsdat.io.retrievers import StorageRetriever
 from tsdat.utils import decode_cf
 
-from .ingest_pipeline import IngestPipeline
 from .add_inputs_attr import add_inputs_attr
+from .ingest_pipeline import IngestPipeline
 
 
 class TransformationPipeline(IngestPipeline):
@@ -74,9 +74,8 @@ class TransformationPipeline(IngestPipeline):
             self.hook_plot_dataset(dataset)
         return dataset
 
-    @staticmethod
     def hook_customize_input_datasets(
-        input_datasets: Dict[str, xr.Dataset], **kwargs: Any
+        self, input_datasets: Dict[str, xr.Dataset], **kwargs: Any
     ) -> Dict[str, xr.Dataset]:
         """-----------------------------------------------------------------------------
         Code hook to customize any input datasets prior to datastreams being combined


### PR DESCRIPTION
code hooks shouldn't have been converted into staticmethods in a recent refactor. My bad. This should fix it.