### PR TITLE
Add UnitsConverter automatically

### DIFF
--- a/test/io/test_retrievers.py
+++ b/test/io/test_retrievers.py
@@ -11,9 +11,11 @@ from tsdat import (
     DatasetConfig,
     DefaultRetriever,
     FileSystem,
+    RetrievedVariable,
     RetrieverConfig,
     StorageRetriever,
     StorageRetrieverInput,
+    UnitsConverter,
     assert_close,
     recursive_instantiate,
 )
@@ -76,6 +78,12 @@ def vap_transform_dataset_config() -> DatasetConfig:
 @fixture
 def dataset_config() -> DatasetConfig:
     return DatasetConfig.from_yaml(Path("test/config/yaml/dataset.yaml"))
+
+
+def test_retrieved_variable_adds_units_converter_by_default():
+    var = RetrievedVariable(name="foo")
+    assert len(var.data_converters) == 1
+    assert isinstance(var.data_converters[0], UnitsConverter)
 
 
 def test_storage_retriever_input_key():
@@ -178,7 +186,11 @@ def test_storage_retriever(
     )
 
     expected = xr.Dataset(
-        coords={"time": pd.date_range("2022-04-05", "2022-04-06", periods=3 + 1, inclusive="left")},  # type: ignore
+        coords={
+            "time": pd.date_range(
+                "2022-04-05", "2022-04-06", periods=3 + 1, inclusive="left"
+            )
+        },  # type: ignore
         data_vars={
             "temperature": (  # degF -> degC
                 "time",

--- a/tsdat/io/base/retrieved_variable.py
+++ b/tsdat/io/base/retrieved_variable.py
@@ -14,10 +14,10 @@ class RetrievedVariable(BaseModel, extra=Extra.forbid):
     """Tracks the name of the input variable and the converters to apply."""
 
     name: Union[str, List[str]]
-    data_converters: List[DataConverter] = Field(default_factory=lambda: list)
+    data_converters: List[DataConverter] = Field(default_factory=list)
     source: InputKey = ""
 
-    @validator("data_converters")
+    @validator("data_converters", always=True)
     def add_units_converter(
         cls, data_converters: list[DataConverter]
     ) -> list[DataConverter]:

--- a/tsdat/io/base/retrieved_variable.py
+++ b/tsdat/io/base/retrieved_variable.py
@@ -3,10 +3,10 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field, validator
 
-from .data_converter import DataConverter
 from ...const import InputKey
+from .data_converter import DataConverter
 
 
 # TODO: This needs a better name
@@ -14,5 +14,15 @@ class RetrievedVariable(BaseModel, extra=Extra.forbid):
     """Tracks the name of the input variable and the converters to apply."""
 
     name: Union[str, List[str]]
-    data_converters: List[DataConverter] = []
+    data_converters: List[DataConverter] = Field(default_factory=lambda: list)
     source: InputKey = ""
+
+    @validator("data_converters")
+    def add_units_converter(
+        cls, data_converters: list[DataConverter]
+    ) -> list[DataConverter]:
+        from ..converters.units_converter import UnitsConverter
+
+        if not any(isinstance(dc, UnitsConverter) for dc in data_converters):
+            data_converters.append(UnitsConverter())
+        return data_converters


### PR DESCRIPTION
This PR adds a `UnitsConverter` to the list of `data_converters` for every retrieved variable, if it doesn't already define a `UnitsConverter`. The new `UnitsConverter` will attempt to automatically detect the input units from the input dataset (`variable.attrs.get("units")`). If no units are found, or if the units are `"1"`, then the conversion is skipped.