### PR TITLE
Allow relative paths in config files

### DIFF
--- a/test/config/test_pipeline_config.py
+++ b/test/config/test_pipeline_config.py
@@ -32,6 +32,7 @@ def test_pipeline_config_merges_overrides():
         "dataset": model_to_dict(dataset),
         "quality": model_to_dict(quality),
         "storage": model_to_dict(storage),
+        "cfg_filepath": Path("test/config/yaml/pipeline.yaml"),
     }
     expected_dict["storage"]["parameters"]["data_storage_path"] = "data/{datastream}"
 

--- a/test/config/test_pipeline_config.py
+++ b/test/config/test_pipeline_config.py
@@ -3,6 +3,9 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict
 
+import pytest
+
+from tsdat import ConfigError
 from tsdat.config.dataset import DatasetConfig
 from tsdat.config.pipeline import PipelineConfig
 from tsdat.config.quality import QualityConfig
@@ -41,6 +44,14 @@ def test_pipeline_config_merges_overrides():
     model_dict = model_to_dict(pipeline_model)
 
     assert model_dict == expected_dict
+
+
+def test_pipeline_config_raises_error():
+    with pytest.raises(ConfigError):
+        PipelineConfig.from_yaml(
+            Path("test/config/yaml/invalid-pipeline.yaml"),
+            overrides={"/triggers": []},
+        )
 
 
 def test_pipeline_config_can_generate_schema():

--- a/test/config/yaml/invalid-pipeline.yaml
+++ b/test/config/yaml/invalid-pipeline.yaml
@@ -1,0 +1,7 @@
+classname: test.pipeline.examples.Ingest
+
+triggers:
+  - '.*\.csv'
+
+retriever:
+  path: ./retriever.yaml

--- a/test/config/yaml/pipeline.yaml
+++ b/test/config/yaml/pipeline.yaml
@@ -18,7 +18,8 @@ quality:
     /managers/0/exclude: []
 
 storage:
-  path: test/config/yaml/storage.yaml
-  overrides:
-    /parameters:
+  classname: tsdat.io.storage.FileSystem
+  parameters:
       data_storage_path: data/{datastream}
+  handler:
+    classname: tsdat.io.handlers.NetCDFHandler

--- a/test/config/yaml/pipeline.yaml
+++ b/test/config/yaml/pipeline.yaml
@@ -4,10 +4,10 @@ triggers:
   - '.*\.csv'
 
 retriever:
-  path: test/config/yaml/retriever.yaml
+  path: ./retriever.yaml
 
 dataset:
-  path: test/config/yaml/dataset.yaml
+  path: ../yaml/dataset.yaml
   overrides:
     /attrs/location_id: sgp
     /data_vars/first/attrs/new_attribute: please add this attribute

--- a/tsdat/config/pipeline/pipeline_config.py
+++ b/tsdat/config/pipeline/pipeline_config.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Pattern, Union
 
 from jsonpointer import set_pointer  # type: ignore
 from pydantic import (
-    ConfigError,
     Extra,
     Field,
     ValidationError,
@@ -16,6 +15,7 @@ from ..dataset import DatasetConfig
 from ..quality import QualityConfig
 from ..storage import StorageConfig
 from ..utils import (
+    ConfigError,
     Overrideable,
     ParameterizedConfigClass,
     matches_overridable_schema,
@@ -124,8 +124,7 @@ class PipelineConfig(ParameterizedConfigClass, extra=Extra.allow):
 
     @classmethod
     def from_yaml(cls, filepath: Path, overrides: Optional[Dict[str, Any]] = None):
-        """------------------------------------------------------------------------------------
-        Creates a python configuration object from a yaml file.
+        """Creates a python configuration object from a yaml file.
 
         Args:
             filepath (Path): The path to the yaml file
@@ -135,7 +134,6 @@ class PipelineConfig(ParameterizedConfigClass, extra=Extra.allow):
         Returns:
             YamlModel: A YamlModel subclass
 
-        ------------------------------------------------------------------------------------
         """
         config = read_yaml(filepath)
         if overrides:
@@ -150,29 +148,22 @@ class PipelineConfig(ParameterizedConfigClass, extra=Extra.allow):
 
     @classmethod
     def generate_schema(cls, output_file: Path):
-        """------------------------------------------------------------------------------------
-        Generates JSON schema from the model fields and type annotations.
+        """Generates JSON schema from the model fields and type annotations.
 
         Args:
             output_file (Path): The path to store the JSON schema.
-
-        ------------------------------------------------------------------------------------
         """
         output_file.write_text(cls.schema_json(indent=4))
 
     def instantiate_pipeline(self) -> Pipeline:
-        """------------------------------------------------------------------------------------
-        Loads the tsdat.pipeline.BasePipeline subclass specified by the classname property.
+        """Loads the tsdat.pipeline.BasePipeline subclass specified by the classname property.
 
         Properties and sub-properties of the PipelineConfig class that are subclasses of
         tsdat.config.utils.ParameterizedConfigClass (e.g, classes that define a 'classname' and
         optional 'parameters' properties) will also be instantiated in similar fashion. See
         tsdat.config.utils.recursive_instantiate for implementation details.
 
-
         Returns:
             Pipeline: An instance of a tsdat.pipeline.base.Pipeline subclass.
-
-        ------------------------------------------------------------------------------------
         """
         return recursive_instantiate(self)

--- a/tsdat/config/utils/__init__.py
+++ b/tsdat/config/utils/__init__.py
@@ -1,22 +1,15 @@
-from ._named_class import _NamedClass
-from .config import Config
-from .config_error import ConfigError
-from .overrideable import Overrideable
-from .parameterized_config_class import ParameterizedConfigClass
-from .yaml_model import YamlModel
-
-from .find_duplicates import find_duplicates
-from .get_code_version import get_code_version
-from .matches_overrideable_schema import matches_overrideable_schema
-from .read_yaml import read_yaml
-from .recursive_instantiate import recursive_instantiate
-
-__all__ = [
-    "ConfigError",
-    "Overrideable",
-    "ParameterizedConfigClass",
-    "YamlModel",
-    "get_code_version",
-    "read_yaml",
-    "recursive_instantiate",
-]
+from ._named_class import _NamedClass as _NamedClass
+from .config import Config as Config
+from .config_error import ConfigError as ConfigError
+from .find_duplicates import find_duplicates as find_duplicates
+from .get_code_version import get_code_version as get_code_version
+from .matches_overridable_schema import (
+    matches_overridable_schema as matches_overridable_schema,
+)
+from .overrideable import Overrideable as Overrideable
+from .parameterized_config_class import (
+    ParameterizedConfigClass as ParameterizedConfigClass,
+)
+from .read_yaml import read_yaml as read_yaml
+from .recursive_instantiate import recursive_instantiate as recursive_instantiate
+from .yaml_model import YamlModel as YamlModel

--- a/tsdat/config/utils/matches_overridable_schema.py
+++ b/tsdat/config/utils/matches_overridable_schema.py
@@ -4,5 +4,5 @@ from typing import (
 )
 
 
-def matches_overrideable_schema(model_dict: Dict[str, Any]):
+def matches_overridable_schema(model_dict: Dict[str, Any]):
     return "path" in model_dict

--- a/tsdat/pipeline/base/pipeline.py
+++ b/tsdat/pipeline/base/pipeline.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from getpass import getuser
-from typing import Any, Iterable, List, Pattern, cast
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Pattern, cast
 
 import numpy as np
 import xarray as xr
@@ -36,6 +37,9 @@ class Pipeline(ParameterizedClass, ABC):
 
     storage: Storage
     """Stores the dataset so it can be retrieved later."""
+
+    cfg_filepath: Optional[Path] = None
+    """The pipeline.yaml file containing the parameters used to instantiate this object"""
 
     @abstractmethod
     def run(self, inputs: List[str], **kwargs: Any) -> Any:


### PR DESCRIPTION
This PR allows relative paths in pipeline config files. See #174 for more details, but the gist is that this is now doable (and recommended, since it is more readable):


**`pipelines/example/config/pipeline.yaml`**

```yaml
classname: pipelines.example.pipeline.Ingest
triggers: ['.*\.csv']

retriever:
  path: ./retriever.yaml  # --> pipelines/example/config/retriever.yaml

dataset:
  path: ./dataset.yaml  # --> pipelines/example/config/dataset.yaml

quality:
  path: ../config/quality.yaml  # --> pipelines/example/config/quality.yaml

storage:
  path: shared/storage.yaml  # can also use the same paths as before
```