### PR TITLE
Add documentation 

### DIFF
--- a/docs/config/dataset_config.md
+++ b/docs/config/dataset_config.md
@@ -21,7 +21,7 @@ the configuration should be tweaked according to the specifics of your dataset. 
 
 ## Sample Configuration of Dataset.yaml
 
-This sample configuration illustrates the structure of a dataset.yaml file used in TSDAT, outlining essential components such as metadata attributes, coordinate definitions, and data variable specifications. It serves as a template for defining time-series datasets, divided into three main sections: 'attrs', 'coords', and 'data_vars'. Annotations throughout the sample explain each section's purpose and field meanings, facilitating easy adaptation to specific data requirements.
+This sample configuration illustrates the structure of a `dataset.yaml` file used in Tsdat, outlining essential components such as metadata attributes, coordinate definitions, and data variable specifications. It serves as a template for defining time-series datasets, divided into three main sections: 'attrs', 'coords', and 'data_vars'. Annotations throughout the sample explain each section's purpose and field meanings, facilitating easy adaptation to specific data requirements.
 
 ```yaml
 # The 'attrs' section defines metadata attributes for the dataset

--- a/docs/config/dataset_config.md
+++ b/docs/config/dataset_config.md
@@ -18,3 +18,37 @@ the configuration should be tweaked according to the specifics of your dataset. 
     Tsdat templates come complete with a VS Code IDE configuration that will provide inline documentation and
     auto-completions for your yaml configuration files. Consult the [tutorials](./pipeline_config.md) section for more
     information on editing your pipeline in VS Code.
+
+## Sample Configuration of Dataset.yaml
+
+This sample configuration illustrates the structure of a dataset.yaml file used in TSDAT, outlining essential components such as metadata attributes, coordinate definitions, and data variable specifications. It serves as a template for defining time-series datasets, divided into three main sections: 'attrs', 'coords', and 'data_vars'. Annotations throughout the sample explain each section's purpose and field meanings, facilitating easy adaptation to specific data requirements.
+
+```yaml
+# The 'attrs' section defines metadata attributes for the dataset
+attrs:
+  title: test  # The title of the dataset
+  description: test_description  # A brief description of the dataset
+  location_id: test_location  # Identifier for the location of the data
+  dataset_name: test  # Name of the dataset
+  data_level: a1  # Data processing level (e.g., raw, quality controlled, etc.)
+  # qualifier:  # Optional: Additional qualifier for the dataset
+  # temporal:  # Optional: Temporal information about the dataset
+  # institution:  # Optional: Institution responsible for the dataset
+
+# The 'coords' section defines the coordinate variables
+coords:
+  time:  # Time coordinate
+    dims: [time]  # Dimension of the time coordinate
+    dtype: datetime64[s]  # Data type for time (datetime with second precision)
+    attrs:
+      units: Seconds since 1970-01-01 00:00:00  # Units for the time coordinate
+
+# The 'data_vars' section defines the data variables in the dataset
+data_vars:
+  example_var:  # Name of the example variable
+    dims: [time]  # Dimension of the variable (using the time coordinate)
+    dtype: float  # Data type of the variable
+    attrs:
+      long_name: Example Variable  # Full descriptive name of the variable
+      units: km  # Units of measurement for the variable
+```

--- a/docs/config/pipeline_config.md
+++ b/docs/config/pipeline_config.md
@@ -127,14 +127,17 @@ When working with an existing ingest, you might need to create a new `pipeline.y
 To keep your project organized, consider adopting a clear and consistent naming convention for your `pipeline.yaml` files. Here are some suggestions:
 
 - **Site-Specific Pipelines:**
+
   - `pipeline_sgp.yaml` for the Southern Great Plains site.
   - `pipeline_nsa.yaml` for the North Slope of Alaska site.
 
 - **Metadata Variations:**
+
   - `pipeline_metadata_v1.yaml` for the first version of metadata.
   - `pipeline_metadata_alt.yaml` for an alternative metadata configuration.
 
 - **Specialized Processing:**
+
   - `pipeline_qc.yaml` for a pipeline focused on quality control.
   - `pipeline_transform.yaml` for pipelines that require specific data transformations.
 
@@ -144,12 +147,13 @@ Let's walk through an example of how to add a new `pipeline.yaml` file:
 
 1. **Duplicate an Existing `pipeline.yaml` File:**
 
-   Navigate to the `pipelines/` directory in your repository.
+    Navigate to the `pipelines/` directory in your repository.
 
-   Copy an existing `pipeline.yaml` file that is closest to what you need:
+    Copy an existing `pipeline.yaml` file that is closest to what you need:
 
-   ```bash
-   cp pipelines/pipeline_sgp.yaml pipelines/pipeline_nsa.yaml
+    ```bash
+    cp pipelines/pipeline_sgp.yaml pipelines/pipeline_nsa.yaml
+    ```
 
 2. **Customize the New pipeline.yaml File:**
 

--- a/docs/config/pipeline_config.md
+++ b/docs/config/pipeline_config.md
@@ -109,3 +109,75 @@ data_vars:
       units: deg
       comment: This is a brand new variable called 'wind_dir'
 ```
+
+## Adding a new pipeline
+
+### Creating a Repository from the Pipeline Template
+
+1. Use the Template:
+    - Go to the [tsdat pipeline-template](https://github.com/tsdat/pipeline-template)repository on GitHub.
+    - Click the "Use this template" button to create a new repository in your GitHub account based on this template.
+    - If you need an older version, select "Include all branches" and set your desired branch as the default.
+2. Clone the Repository:
+    - Click the "Code" button on your new repository page to copy the repository URL.
+    - Open a terminal and run:
+
+      ```bash
+      git clone <your-repository-url>
+      ```
+
+    - Navigate to the cloned repository:
+
+      ```bash
+      cd <your-repository-name>
+      ```
+
+### Setting Up Your Anaconda Environment
+
+1. Open Terminal:
+    - On Linux or Mac, open a regular terminal.
+    - On Windows, open an Anaconda prompt or a WSL terminal if using Windows Subsystem for Linux.
+2. Create and Activate Environment:
+    - Run the following commands:
+
+      ```bash
+      conda env create --file=conda-environment.yaml
+      conda activate tsdat-pipelines
+      ```
+
+3. Verify Environment:
+    - Run tests to ensure the environment is set up correctly:
+
+      ```bash
+      pytest
+      ```
+
+    - If you encounter a pyproj warning, run:
+
+      ```bash
+      conda remove --force pyproj
+      pip install pyproj
+      ```
+
+### Adding a New Pipeline
+
+1. Generate New Pipeline Folder:
+    - From the top-level repository folder, run:
+
+      ```bash
+      make cookies
+      ```
+
+      or
+
+      ```bash
+      cookiecutter templates/ingest -o ingest/
+      ```
+
+    - This command uses cookiecutter to generate a new pipeline folder inside the pipelines/ directory.
+2. Follow Prompts:
+    - Answer the prompts to customize your new pipeline. These prompts will guide you through setting up various aspects of the pipeline, such as naming and configuration.
+3. Review and Customize:
+    - Once cookiecutter completes, a new pipeline folder will appear inside pipelines/.
+    - Open the README.md file in the new pipeline folder for further instructions on configuring, running, testing, and debugging your pipeline.
+    - Customize the pipeline by updating configuration files, setting up input/output paths, and defining necessary data transformations or quality control measures.

--- a/docs/config/pipeline_config.md
+++ b/docs/config/pipeline_config.md
@@ -126,20 +126,20 @@ When working with an existing ingest, you might need to create a new `pipeline.y
 
 To keep your project organized, consider adopting a clear and consistent naming convention for your `pipeline.yaml` files. Here are some suggestions:
 
-- **Site-Specific Pipelines:**
+Site-Specific Pipelines:
 
-  - `pipeline_sgp.yaml` for the Southern Great Plains site.
-  - `pipeline_nsa.yaml` for the North Slope of Alaska site.
+- `pipeline_sgp.yaml` for the Southern Great Plains site.
+- `pipeline_nsa.yaml` for the North Slope of Alaska site.
 
-- **Metadata Variations:**
+Metadata Variations:
 
-  - `pipeline_metadata_v1.yaml` for the first version of metadata.
-  - `pipeline_metadata_alt.yaml` for an alternative metadata configuration.
+- `pipeline_metadata_v1.yaml` for the first version of metadata.
+- `pipeline_metadata_alt.yaml` for an alternative metadata configuration.
 
-- **Specialized Processing:**
+Specialized Processing:
 
-  - `pipeline_qc.yaml` for a pipeline focused on quality control.
-  - `pipeline_transform.yaml` for pipelines that require specific data transformations.
+- `pipeline_qc.yaml` for a pipeline focused on quality control.
+- `pipeline_transform.yaml` for pipelines that require specific data transformations.
 
 #### Example: Adding a New `pipeline.yaml` File
 

--- a/docs/config/pipeline_config.md
+++ b/docs/config/pipeline_config.md
@@ -110,74 +110,59 @@ data_vars:
       comment: This is a brand new variable called 'wind_dir'
 ```
 
-## Adding a new pipeline
+## Adding a New Pipeline
 
-### Creating a Repository from the Pipeline Template
+### Creating a New `pipeline.yaml` File
 
-1. Use the Template:
-    - Go to the [tsdat pipeline-template](https://github.com/tsdat/pipeline-template)repository on GitHub.
-    - Click the "Use this template" button to create a new repository in your GitHub account based on this template.
-    - If you need an older version, select "Include all branches" and set your desired branch as the default.
-2. Clone the Repository:
-    - Click the "Code" button on your new repository page to copy the repository URL.
-    - Open a terminal and run:
+When working with an existing ingest, you might need to create a new `pipeline.yaml` file to accommodate different configurations. For example, you may want to set up pipelines for different sites, apply different metadata, or handle other specific processing needs. Adding a new `pipeline.yaml` file allows you to maintain organization and flexibility within your project.
 
-      ```bash
-      git clone <your-repository-url>
-      ```
+#### Reasons for Adding a New `pipeline.yaml` File
 
-    - Navigate to the cloned repository:
+- **Different Site Configurations:** If you're processing data from multiple sites, each site may have unique settings or parameters. Creating separate `pipeline.yaml` files for each site ensures that these configurations are handled properly.
+- **Varying Metadata:** Different datasets might require distinct metadata configurations. Separate `pipeline.yaml` files can help manage these variations efficiently.
+- **Specialized Processing:** You might need different processing steps or quality control measures for different datasets. Multiple `pipeline.yaml` files allow you to customize these processes without disrupting the overall pipeline structure.
 
-      ```bash
-      cd <your-repository-name>
-      ```
+#### Suggested Naming Conventions
 
-### Setting Up Your Anaconda Environment
+To keep your project organized, consider adopting a clear and consistent naming convention for your `pipeline.yaml` files. Here are some suggestions:
 
-1. Open Terminal:
-    - On Linux or Mac, open a regular terminal.
-    - On Windows, open an Anaconda prompt or a WSL terminal if using Windows Subsystem for Linux.
-2. Create and Activate Environment:
-    - Run the following commands:
+- **Site-Specific Pipelines:**
+  - `pipeline_sgp.yaml` for the Southern Great Plains site.
+  - `pipeline_nsa.yaml` for the North Slope of Alaska site.
 
-      ```bash
-      conda env create --file=conda-environment.yaml
-      conda activate tsdat-pipelines
-      ```
+- **Metadata Variations:**
+  - `pipeline_metadata_v1.yaml` for the first version of metadata.
+  - `pipeline_metadata_alt.yaml` for an alternative metadata configuration.
 
-3. Verify Environment:
-    - Run tests to ensure the environment is set up correctly:
+- **Specialized Processing:**
+  - `pipeline_qc.yaml` for a pipeline focused on quality control.
+  - `pipeline_transform.yaml` for pipelines that require specific data transformations.
 
-      ```bash
-      pytest
-      ```
+#### Example: Adding a New `pipeline.yaml` File
 
-    - If you encounter a pyproj warning, run:
+Let's walk through an example of how to add a new `pipeline.yaml` file:
 
-      ```bash
-      conda remove --force pyproj
-      pip install pyproj
-      ```
+1. **Duplicate an Existing `pipeline.yaml` File:**
 
-### Adding a New Pipeline
+   Navigate to the `pipelines/` directory in your repository.
 
-1. Generate New Pipeline Folder:
-    - From the top-level repository folder, run:
+   Copy an existing `pipeline.yaml` file that is closest to what you need:
 
-      ```bash
-      make cookies
-      ```
+   ```bash
+   cp pipelines/pipeline_sgp.yaml pipelines/pipeline_nsa.yaml
 
-      or
+2. **Customize the New pipeline.yaml File:**
 
-      ```bash
-      cookiecutter templates/ingest -o ingest/
-      ```
+    Open the newly created pipeline_nsa.yaml file in your text editor.
 
-    - This command uses cookiecutter to generate a new pipeline folder inside the pipelines/ directory.
-2. Follow Prompts:
-    - Answer the prompts to customize your new pipeline. These prompts will guide you through setting up various aspects of the pipeline, such as naming and configuration.
-3. Review and Customize:
-    - Once cookiecutter completes, a new pipeline folder will appear inside pipelines/.
-    - Open the README.md file in the new pipeline folder for further instructions on configuring, running, testing, and debugging your pipeline.
-    - Customize the pipeline by updating configuration files, setting up input/output paths, and defining necessary data transformations or quality control measures.
+    Update the configurations, such as site name, paths, metadata, and any specific processing steps required for this pipeline.
+
+3. **Integrate the New Pipeline:**
+
+    Ensure that your project references the new pipeline.yaml file correctly.
+
+    Update any scripts or configurations that need to utilize the new pipeline.
+
+4. **Test the New Pipeline:**
+
+    Run tests to verify that the new pipeline functions as expected. This might include running the pipeline on sample data and checking the output against expected results.

--- a/docs/config/retriever_config.md
+++ b/docs/config/retriever_config.md
@@ -97,3 +97,48 @@ def convert(
         xr.DataArray: The converted DataArray for the specified variable.
     """
 ```
+
+## Coords
+
+The coords section in the retriever.yaml file specifies the coordinate variables that are used to read and interpret raw input data. This section defines the dimensions and attributes of the coordinates, such as time or spatial coordinates, which are essential for accurately mapping the data within the dataset. The configuration ensures that the data is properly aligned and can be processed effectively by the tsdat framework
+
+```yaml
+coords:
+  # Specify the coords that should be retrieved from any inputs
+  time:  # Coordinate variable for time
+    # Mapping of regex pattern (matching input key/file) to input name & converter(s) to
+    # run. The default is .*, which matches everything. Put the most specific patterns
+    # first because searching happens top -> down and stops at the first match.
+    .*:  # Regex pattern to match all input keys/files
+      # The name of the input variable as returned by the selected reader. If using a
+      # built-in DataReader like the CSVReader or NetCDFReader, then will be exactly the
+      # same as the name of the variable in the input file.
+      name: Timestamp (end of interval)  # Name of the input variable in the raw data
+
+      # Optionally specify converters to run. The one below converts string values into
+      # datetime64 objects. It requests two arguments: format and timezone. Format is
+      # the string time format of the input data (see strftime.org for more info), and
+      # timezone is the timezone of the input measurement.
+      data_converters:  # List of converters to apply to the input data
+        - classname: tsdat.io.converters.StringToDatetime  # Converter class to use
+          format: "%Y-%m-%d %H:%M:%S"  # Format of the time string in the input data
+          timezone: UTC  # Timezone of the input data
+```
+
+## Data_vars
+
+Data_vars are used to specify the data variables that should be retrieved from the input data sources. Similar to the coords section, data_vars define how to read and preprocess variables from the raw input data, including the variable name, its source in the input data, and any data converters to be applied. Each data_var entry typically includes information on how to handle the data, such as unit conversions or other preprocessing steps, and uses regex patterns to match input sources.
+
+```yaml
+data_vars:
+  example_var:  # Data variable name to be used in the processed dataset
+    .*:  # Regex pattern to match all input keys/files
+      name: Example  # Name of the input variable in the raw data
+
+      # Optionally specify converters to run. The one below converts units of the input
+      # data. It requests the input_units argument, which specifies the units of the
+      # input measurement.
+      data_converters:  # List of converters to apply to the input data
+        - classname: tsdat.io.converters.UnitsConverter  # Converter class to use
+          input_units: km  # Units of the input data to be converted
+```

--- a/docs/config/retriever_config.md
+++ b/docs/config/retriever_config.md
@@ -98,9 +98,9 @@ def convert(
     """
 ```
 
-## Coords
+## Coordinates
 
-The coords section in the retriever.yaml file specifies the coordinate variables that are used to read and interpret raw input data. This section defines the dimensions and attributes of the coordinates, such as time or spatial coordinates, which are essential for accurately mapping the data within the dataset. The configuration ensures that the data is properly aligned and can be processed effectively by the tsdat framework
+The coordinates section in the `retriever.yaml` file specifies the coordinate variables that are used to read and interpret raw input data. This section defines the dimensions and attributes of the coordinates, such as time or spatial coordinates, which are essential for accurately mapping the data within the dataset. The configuration ensures that the data is properly aligned and can be processed effectively by the tsdat framework
 
 ```yaml
 coords:
@@ -125,9 +125,9 @@ coords:
           timezone: UTC  # Timezone of the input data
 ```
 
-## Data_vars
+## Data Variables
 
-Data_vars are used to specify the data variables that should be retrieved from the input data sources. Similar to the coords section, data_vars define how to read and preprocess variables from the raw input data, including the variable name, its source in the input data, and any data converters to be applied. Each data_var entry typically includes information on how to handle the data, such as unit conversions or other preprocessing steps, and uses regex patterns to match input sources.
+`Data_vars` are used to specify the data variables that should be retrieved from the input data sources. Similar to the coords section, `data_vars` define how to read and preprocess variables from the raw input data, including the variable name, its source in the input data, and any data converters to be applied. Each `data_var` entry typically includes information on how to handle the data, such as unit conversions or other preprocessing steps, and uses regex patterns to match input sources.
 
 ```yaml
 data_vars:

--- a/test/io/test_a2e_csv.py
+++ b/test/io/test_a2e_csv.py
@@ -60,7 +60,10 @@ def test_1D_dataset_roundtrip(multi_var_1D_dataset: xr.Dataset):
     expected.attrs["number"] = str(expected.attrs["number"])  # Note: writer does not
     expected.attrs["array"] = str(expected.attrs["array"])  # preserve the attr dtypes.
     expected["first"].attrs["number"] = str(expected["first"].attrs["number"])
-    expected["scalar"] = (("time"), [expected["scalar"].values] * expected.dims["time"])
+    expected["scalar"] = (
+        ("time"),
+        [expected["scalar"].values] * expected.sizes["time"],
+    )
     assert_close(dataset, expected, check_attrs=True)
 
 


### PR DESCRIPTION
Add documentation for dataset.yaml (Sample Configuration of Dataset.yaml) abd retriever.yaml (Section for Coords and Data_vars)

Task: 
The developer guide --> dataset config page should contain an annotated example of a dataset config file
The retriever configuration in the developer guide only covers readers and converters. It should also cover the settings for coords and data_vars