### PR TITLE
Fix matplotlib version for mhkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ io = [
   "pyarrow",
   "zarr",
 ]
-ocean = ["mhkit"]
+ocean = [
+  "mhkit",
+  "matplotlib!=3.9.1.post1",  # mhkit doesn't like this version string
+]
 
 [project.scripts]
 tsdat = "tsdat.cli:app"


### PR DESCRIPTION
`Mhkit` attempts to parse the version numbers from matplotlib, but fails for the current latest release of matplotlib (`3.9.1.post1`) because the `.post1` suffix can't be converted to a number using `int()`. This PR just installs a different version of matplotlib if tsdat is installed using the `tsdat[ocean]` qualifier to get around this.